### PR TITLE
Add NDJSON input support via -j/--jsonl

### DIFF
--- a/.agents/skills/json-shape/SKILL.md
+++ b/.agents/skills/json-shape/SKILL.md
@@ -16,8 +16,8 @@ reading the whole payload into context.
 
 - You're about to parse an API response, config file, or data export and don't know its shape.
 - A JSON file is too large or repetitive to paste, but you need its structure.
-- You have an array of sample records and want one merged shape showing which fields are
-  optional and which vary in type.
+- You have an array of sample records, or a newline-delimited JSON (NDJSON) file, and want one
+  merged shape showing which fields are optional and which vary in type.
 - You need a real JSON Schema (draft-07) document to hand to a validator or code generator.
 
 ## Usage
@@ -42,6 +42,7 @@ own — choose them using the guidance below.
 | --- | --- |
 | `-l`, `--llm` | **Default choice.** Compact, punctuation-free notation — cheapest to read. |
 | `-m`, `--merge-samples` | The input is a top-level *array of sample records* rather than one document. Folds them into a single shape: fields missing from some samples get `?`, fields whose type varies become a `\|` union. |
+| `-j`, `--jsonl` | The input is newline-delimited JSON (NDJSON) — one JSON value per line — instead of a single document or array. Merges the values the same way `-m` merges array elements; `-m` itself has no effect when `-j` is set. |
 | `-s`, `--json-schema` | Only when a real JSON Schema document is explicitly wanted. Much more verbose than `-l`. |
 | *(none)* | The default JSON-shaped compact notation. Prefer `-l` unless you specifically want valid JSON out. |
 
@@ -83,7 +84,13 @@ name: string
 Here `email` was absent from at least one record, and `id` appeared as both an integer and a
 string — the kind of detail worth knowing *before* writing the parsing code.
 
-The `-l` notation is specified in full in the project README's "Example6: LLM-Optimized
+Merging a newline-delimited JSON (NDJSON) file — no need to wrap it in `[` `]` first:
+
+```shell
+bash scripts/analyze.sh -l -j -i samples.ndjson
+```
+
+The `-l` notation is specified in full in the project README's "Example7: LLM-Optimized
 Output" section.
 
 ## Requirements and troubleshooting
@@ -95,6 +102,6 @@ The script prefers a locally-built jar, searching upward from the current direct
 released jar to `~/.cache/json-schema-analyzer/` (override with `JSON_SCHEMA_ANALYZER_CACHE`)
 and reuses it on later runs.
 
-If you see `Unknown option: '-l'` (or `-m`/`-s`), the jar being used predates that flag —
+If you see `Unknown option: '-l'` (or `-m`/`-j`/`-s`), the jar being used predates that flag —
 almost always the downloaded release rather than a local build. Building the repo locally
 (`mvn clean install`) makes the script prefer that fresh jar instead.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ java -jar json-schema-analyzer-<version>.jar -i example.json
 * [Build](#build)
 * [CLI](#cli)
 * [Examples](#examples)
-  * [Example6: LLM-Optimized Output](#example6-llm-optimized-output)
+  * [Example7: LLM-Optimized Output](#example7-llm-optimized-output)
 * [Error Handling](#error-handling)
 * [Using as a Library](#using-as-a-library)
 * [Agent Skills](#agent-skills)
@@ -115,11 +115,15 @@ To build a native binary yourself, use a [GraalVM](https://www.graalvm.org/) JDK
 
 ## CLI 
 ```shell
-Usage: json-analyze [-hlmsV] [-i=<file>]
+Usage: json-analyze [-hjlmsV] [-i=<file>]
 Describes the fields and datatypes in a JSON document.
   -h, --help                Show this help message and exit.
   -i, --input-file=<file>   The JSON file to analyze; reads from stdin if
                               omitted
+  -j, --jsonl                Read the input as newline-delimited JSON (NDJSON),
+                              treating each value as one sample and merging
+                              them into a single shape, like -m does for a
+                              JSON array
   -l, --llm                 Print the shape in a compact, punctuation-free
                               notation designed to be pasted into an LLM prompt
                               cheaply, instead of the default compact notation
@@ -280,7 +284,37 @@ java -jar json-schema-analyzer-<version>.jar -i nested-samples.json -m
 }
 ```
 
-### Example5: JSON Schema Output
+### Example5: NDJSON Input
+
+Pass `-j`/`--jsonl` when the input is newline-delimited JSON (NDJSON) — one JSON value per line,
+as produced by log exports or streaming APIs — rather than a single document. Each value is
+treated as a sample and merged into one shape exactly the way `-m` merges elements of a JSON
+array, so there's no need to wrap the lines in `[` `]` first or hold them all in memory as one
+array.
+
+```shell
+cat <<EOF >samples.ndjson
+{"id": 1, "name": "Alice", "email": "a@example.com"}
+{"id": 2, "name": "Bob"}
+{"id": "3", "name": "Carol"}
+EOF
+java -jar json-schema-analyzer-<version>.jar -i samples.ndjson -j
+```
+
+would produce the following output
+
+```json
+{
+  "email?" : "string",
+  "id" : "integer|string",
+  "name" : "string"
+}
+```
+
+It composes with `-s` and `-l` the same way `-m` does. `-m` itself has no effect when `-j` is
+set, since NDJSON input is always merged.
+
+### Example6: JSON Schema Output
 
 Pass `-s`/`--json-schema` to print the shape as a real [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
 document instead of the default compact notation — composes with `-m` the same way. Note that
@@ -333,7 +367,7 @@ would produce the following output
 }
 ```
 
-### Example6: LLM-Optimized Output
+### Example7: LLM-Optimized Output
 
 Pass `-l`/`--llm` to print the shape in a compact notation with no braces, quotes, or commas —
 nesting is indentation only, array-typed fields get a trailing `[]`, and optional/union fields
@@ -400,6 +434,10 @@ can pattern-match on it directly. `SchemaMerger.merge(a, b)` is available the sa
 multiple samples into one shape, exactly as the CLI's `-m` flag does internally. To render a shape
 the way the CLI does, use `Json.write(schema)` for the compact notation or
 `JsonSchemaWriter.toJsonSchema(schema)` for a draft-07 document.
+
+For newline-delimited JSON, `analyzer.parseJsonLines(inputStream)` reads a stream of
+whitespace-separated JSON values — one per line, by NDJSON convention — and merges them into a
+single shape, exactly as the CLI's `-j` flag does.
 
 Collections returned by `getFields()`, `getOptionalFields()`, and `getMembers()` are unmodifiable
 views. If you build shapes by hand rather than getting them from `parse()`, finish building a type

--- a/cli/src/main/java/io/github/ssullivan/Main.java
+++ b/cli/src/main/java/io/github/ssullivan/Main.java
@@ -65,6 +65,10 @@ public final class Main {
                 description = "Treat each element of a top-level JSON array as one sample and merge them into a single shape")
         private boolean mergeSamples;
 
+        @CommandLine.Option(names = {"-j", "--jsonl"},
+                description = "Read the input as newline-delimited JSON (NDJSON), treating each value as one sample and merging them into a single shape, like -m does for a JSON array")
+        private boolean jsonLines;
+
         @CommandLine.Option(names = {"-s", "--json-schema"},
                 description = "Print the shape as a JSON Schema (draft-07) document instead of the default compact notation")
         boolean jsonSchema;
@@ -81,6 +85,11 @@ public final class Main {
 
             try (InputStream inputStream = file != null ? new FileInputStream(file) : System.in) {
                 JsonSchemaAnalyzer analyzer = new JsonSchemaAnalyzer();
+
+                if (jsonLines) {
+                    return analyzer.parseJsonLines(inputStream);
+                }
+
                 JsonType result = analyzer.parse(inputStream);
 
                 if (mergeSamples && result instanceof ArrayType arrayType) {

--- a/cli/src/test/java/io/github/ssullivan/MainTest.java
+++ b/cli/src/test/java/io/github/ssullivan/MainTest.java
@@ -58,6 +58,36 @@ class MainTest {
     }
 
     @Test
+    void testJsonLinesFlagMergesEachLineAsASample(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir, "{\"id\": 1, \"name\": \"Alice\"}\n{\"id\": 2}\n");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-j");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        ObjectType objectType = (ObjectType) result;
+        assertFalse(objectType.isOptional("id"));
+        assertTrue(objectType.isOptional("name"));
+    }
+
+    @Test
+    void testJsonLinesFlagReadsFromStdin() {
+        InputStream originalStdin = System.in;
+        System.setIn(new ByteArrayInputStream("{\"id\": 1}\n{\"id\": 2}\n".getBytes(StandardCharsets.UTF_8)));
+        try {
+            CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+            int exitCode = commandLine.execute("-j");
+
+            assertEquals(0, exitCode);
+            assertEquals(ObjectType.of("id", ScalarType.INTEGER), commandLine.getExecutionResult());
+        } finally {
+            System.setIn(originalStdin);
+        }
+    }
+
+    @Test
     void testMergeFlagOnNonArrayRootLeavesResultUnchanged(@TempDir Path tempDir) throws IOException {
         Path file = writeJson(tempDir, "{\"id\": 1}");
 

--- a/core/src/main/java/io/github/ssullivan/analyze/JsonSchemaAnalyzer.java
+++ b/core/src/main/java/io/github/ssullivan/analyze/JsonSchemaAnalyzer.java
@@ -40,21 +40,62 @@ public class JsonSchemaAnalyzer {
         try (JsonParser jParser = JSON_FACTORY.createParser(source)) {
             try {
                 jParser.nextToken();
-                JsonToken currentToken = jParser.currentToken();
-                if (currentToken == JsonToken.START_OBJECT) {
-                    ObjectType root = new ObjectType();
-                    handleObjectStruct(jParser, root);
-                    return root;
-                } else if (currentToken == JsonToken.START_ARRAY) {
-                    return handleObjectArray(jParser);
-                } else if (currentToken != null && currentToken.isScalarValue()) {
-                    return convertScalarToken(jParser, currentToken);
-                } else {
-                    throw JsonSchemaAnalysisException.unsupportedRoot(currentToken, jParser.currentLocation());
-                }
+                return parseRootValue(jParser, jParser.currentToken());
             } catch (JsonProcessingException e) {
                 throw JsonSchemaAnalysisException.malformedJson(e);
             }
+        }
+    }
+
+    /**
+     * Creates a single merged {@link JsonType} shape from newline-delimited JSON (NDJSON): a
+     * stream of whitespace-separated JSON values, one conventionally per line. Each value is
+     * treated as a sample and folded into the others via {@link SchemaMerger}, exactly as the
+     * CLI's {@code -m} flag does for elements of a JSON array — a field missing from some
+     * samples becomes optional, and one whose type varies across samples becomes a union.
+     * <p>
+     * Blank lines are ignored. Because Jackson treats all whitespace, including newlines, as
+     * insignificant between tokens, this also tolerates a value's JSON spanning multiple lines.
+     *
+     * @param source a non-null {@link InputStream} that contains NDJSON
+     * @return the merged shape of every value in the stream
+     * @throws IOException                if the source itself cannot be read (a genuine I/O
+     *                                     failure)
+     * @throws JsonSchemaAnalysisException if the source can be read but its content isn't
+     *                                     analyzable (malformed JSON, or no values at all)
+     */
+    public JsonType parseJsonLines(InputStream source) throws IOException {
+        Objects.requireNonNull(source, "The method parameter `source` must not be null");
+
+        try (JsonParser jParser = JSON_FACTORY.createParser(source)) {
+            try {
+                JsonType merged = null;
+                JsonToken token;
+                while ((token = jParser.nextToken()) != null) {
+                    JsonType value = parseRootValue(jParser, token);
+                    merged = merged == null ? value : SchemaMerger.merge(merged, value);
+                }
+                if (merged == null) {
+                    throw JsonSchemaAnalysisException.unsupportedRoot(null, jParser.currentLocation());
+                }
+                return merged;
+            } catch (JsonProcessingException e) {
+                throw JsonSchemaAnalysisException.malformedJson(e);
+            }
+        }
+    }
+
+    private static JsonType parseRootValue(JsonParser jParser, JsonToken currentToken) throws IOException {
+        if (currentToken == JsonToken.START_OBJECT) {
+            ObjectType root = new ObjectType();
+            handleObjectStruct(jParser, root);
+            return root;
+        } else if (currentToken == JsonToken.START_ARRAY) {
+            return handleObjectArray(jParser);
+        } else if (currentToken != null && currentToken.isScalarValue()) {
+            return convertScalarToken(jParser, currentToken);
+        } else {
+            throw JsonSchemaAnalysisException.unsupportedRoot(currentToken, jParser.currentLocation());
         }
     }
 

--- a/core/src/test/java/io/github/ssullivan/JsonSchemaAnalyzerTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonSchemaAnalyzerTest.java
@@ -288,10 +288,72 @@ class JsonSchemaAnalyzerTest {
         assertEquals("disk on fire", exception.getMessage());
     }
 
+    @Test
+    void testParseJsonLinesMergesEachLineAsASample() throws IOException {
+        String ndjson = String.join("\n",
+                "{\"id\": 1, \"name\": \"Alice\", \"email\": \"a@example.com\"}",
+                "{\"id\": 2, \"name\": \"Bob\"}",
+                "{\"id\": \"3\", \"name\": \"Carol\"}");
+
+        JsonType schema = inferSchemaFromLines(ndjson);
+
+        assertInstanceOf(ObjectType.class, schema);
+        ObjectType objectType = (ObjectType) schema;
+        assertFalse(objectType.isOptional("id"));
+        assertFalse(objectType.isOptional("name"));
+        assertTrue(objectType.isOptional("email"));
+        assertInstanceOf(UnionType.class, objectType.getFields().get("id"));
+        assertEquals(
+                Set.of(ScalarType.INTEGER, ScalarType.STRING),
+                ((UnionType) objectType.getFields().get("id")).getMembers()
+        );
+    }
+
+    @Test
+    void testParseJsonLinesSkipsBlankLines() throws IOException {
+        String ndjson = "{\"id\": 1}\n\n   \n{\"id\": 2}\n";
+
+        JsonType schema = inferSchemaFromLines(ndjson);
+
+        assertEquals(ObjectType.of("id", ScalarType.INTEGER), schema);
+    }
+
+    @Test
+    void testParseJsonLinesOnSingleLineReturnsThatLinesShape() throws IOException {
+        JsonType schema = inferSchemaFromLines("{\"id\": 1}");
+
+        assertEquals(ObjectType.of("id", ScalarType.INTEGER), schema);
+    }
+
+    @Test
+    void testParseJsonLinesEmptyInputThrowsHelpfulException() {
+        JsonSchemaAnalysisException exception =
+                assertThrows(JsonSchemaAnalysisException.class, () -> inferSchemaFromLines("  \n  \n"));
+
+        assertTrue(exception.getMessage().contains("empty"));
+    }
+
+    @Test
+    void testParseJsonLinesMalformedLineReportsItsOwnLineNumber() {
+        String ndjson = "{\"id\": 1}\n{\"id\": }\n";
+
+        JsonSchemaAnalysisException exception =
+                assertThrows(JsonSchemaAnalysisException.class, () -> inferSchemaFromLines(ndjson));
+
+        assertTrue(exception.getMessage().contains("line 2"), exception.getMessage());
+    }
+
     private JsonType inferSchema(String json) throws IOException {
         try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
             JsonSchemaAnalyzer jsonSchemaAnalyzer = new JsonSchemaAnalyzer();
             return jsonSchemaAnalyzer.parse(inputStream);
+        }
+    }
+
+    private JsonType inferSchemaFromLines(String ndjson) throws IOException {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonSchemaAnalyzer jsonSchemaAnalyzer = new JsonSchemaAnalyzer();
+            return jsonSchemaAnalyzer.parseJsonLines(inputStream);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `-j`/`--jsonl` to the CLI: reads the input as newline-delimited JSON (NDJSON), treating each value as one sample and merging them into a single shape — the same merge semantics `-m` applies to elements of a JSON array, so fields missing from some samples become optional and fields whose type varies become a union. `-m` has no effect when `-j` is set, since NDJSON input is always merged.
- Adds `JsonSchemaAnalyzer.parseJsonLines(InputStream)` to `core`. It parses the whole input as one continuous stream of whitespace-separated JSON values via a single `JsonParser` (Jackson treats newlines as insignificant whitespace between tokens), so malformed-input errors report the correct line/column in the original stream for free, without manual line-splitting.
- Updates the README (new usage example, CLI help text, "Using as a Library" section) and the `json-shape` agent skill docs to cover the new flag.

## Test plan

- [x] `./mvnw clean install -DskipITs` — full unit test suite passes (new core tests for merging, blank-line tolerance, empty-input and malformed-line error reporting; new CLI tests for `-j` via file and stdin)
- [x] Manual smoke test of the packaged jar: `-j` alone, `-j -l`, and a malformed NDJSON line reporting the correct source line number in its error message
- Note: `ShadedJarIT` integration tests fail in this sandbox due to `JAVA_TOOL_OPTIONS` proxy settings polluting stdout — confirmed pre-existing on `main` (unrelated to this change) by stashing and re-running.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAJqLraEZMGqPR5QVfXiwa)_