### PR TITLE
Land string format detection on main

### DIFF
--- a/.agents/skills/json-shape/SKILL.md
+++ b/.agents/skills/json-shape/SKILL.md
@@ -18,6 +18,8 @@ reading the whole payload into context.
 - A JSON file is too large or repetitive to paste, but you need its structure.
 - You have an array of sample records, or a newline-delimited JSON (NDJSON) file, and want one
   merged shape showing which fields are optional and which vary in type.
+- Field values look like dates, timestamps, or UUIDs and you want that reflected in the output
+  instead of everything reported as a generic string.
 - You need a real JSON Schema (draft-07) document to hand to a validator or code generator.
 
 ## Usage
@@ -43,6 +45,7 @@ own — choose them using the guidance below.
 | `-l`, `--llm` | **Default choice.** Compact, punctuation-free notation — cheapest to read. |
 | `-m`, `--merge-samples` | The input is a top-level *array of sample records* rather than one document. Folds them into a single shape: fields missing from some samples get `?`, fields whose type varies become a `\|` union. |
 | `-j`, `--jsonl` | The input is newline-delimited JSON (NDJSON) — one JSON value per line — instead of a single document or array. Merges the values the same way `-m` merges array elements; `-m` itself has no effect when `-j` is set. |
+| `-f`, `--detect-formats` | String values may be dates (`YYYY-MM-DD`), timestamps (RFC 3339), or UUIDs, and you want that reflected in the output instead of everything reported as generic `string`. Off by default. |
 | `-s`, `--json-schema` | Only when a real JSON Schema document is explicitly wanted. Much more verbose than `-l`. |
 | *(none)* | The default JSON-shaped compact notation. Prefer `-l` unless you specifically want valid JSON out. |
 
@@ -90,7 +93,20 @@ Merging a newline-delimited JSON (NDJSON) file — no need to wrap it in `[` `]`
 bash scripts/analyze.sh -l -j -i samples.ndjson
 ```
 
-The `-l` notation is specified in full in the project README's "Example7: LLM-Optimized
+Detecting string formats:
+
+```shell
+bash scripts/analyze.sh -l -f -i events.json
+```
+
+```
+createdAt: date-time
+day: date
+id: uuid
+note: string
+```
+
+The `-l` notation is specified in full in the project README's "Example8: LLM-Optimized
 Output" section.
 
 ## Requirements and troubleshooting
@@ -102,6 +118,6 @@ The script prefers a locally-built jar, searching upward from the current direct
 released jar to `~/.cache/json-schema-analyzer/` (override with `JSON_SCHEMA_ANALYZER_CACHE`)
 and reuses it on later runs.
 
-If you see `Unknown option: '-l'` (or `-m`/`-j`/`-s`), the jar being used predates that flag —
-almost always the downloaded release rather than a local build. Building the repo locally
+If you see `Unknown option: '-l'` (or `-m`/`-j`/`-f`/`-s`), the jar being used predates that
+flag — almost always the downloaded release rather than a local build. Building the repo locally
 (`mvn clean install`) makes the script prefer that fresh jar instead.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ java -jar json-schema-analyzer-<version>.jar -i example.json
 * [Build](#build)
 * [CLI](#cli)
 * [Examples](#examples)
-  * [Example7: LLM-Optimized Output](#example7-llm-optimized-output)
+  * [Example8: LLM-Optimized Output](#example8-llm-optimized-output)
 * [Error Handling](#error-handling)
 * [Using as a Library](#using-as-a-library)
 * [Agent Skills](#agent-skills)
@@ -115,8 +115,11 @@ To build a native binary yourself, use a [GraalVM](https://www.graalvm.org/) JDK
 
 ## CLI 
 ```shell
-Usage: json-analyze [-hjlmsV] [-i=<file>]
+Usage: json-analyze [-fhjlmsV] [-i=<file>]
 Describes the fields and datatypes in a JSON document.
+  -f, --detect-formats      Detect string formats (date, date-time, uuid)
+                              instead of reporting every string as the generic
+                              "string" type
   -h, --help                Show this help message and exit.
   -i, --input-file=<file>   The JSON file to analyze; reads from stdin if
                               omitted
@@ -314,7 +317,38 @@ would produce the following output
 It composes with `-s` and `-l` the same way `-m` does. `-m` itself has no effect when `-j` is
 set, since NDJSON input is always merged.
 
-### Example6: JSON Schema Output
+### Example6: String Format Detection
+
+Pass `-f`/`--detect-formats` to have string values checked against three known formats — ISO
+8601 dates (`YYYY-MM-DD`), RFC 3339 timestamps, and canonical UUIDs — instead of every string
+being reported as the generic `string` type. Off by default, so existing output is unaffected
+unless you opt in.
+
+```shell
+cat <<EOF >events.json
+{"id": "550e8400-e29b-41d4-a716-446655440000", "createdAt": "2023-06-01T14:22:00Z", "day": "2023-06-01", "note": "hello"}
+EOF
+java -jar json-schema-analyzer-<version>.jar -i events.json -f
+```
+
+would produce the following output
+
+```json
+{
+  "createdAt" : "date-time",
+  "day" : "date",
+  "id" : "uuid",
+  "note" : "string"
+}
+```
+
+It composes with `-m`, `-j`, `-s`, and `-l` the same way the other flags do. When merged samples
+disagree on a field's format — one row has a `date`, another has a plain string, or two rows
+disagree on which format — the field falls back to the generic `string` type rather than
+reporting a `date|uuid`-style union, since knowing *a* format was ambiguous is more useful than
+an unreadable mix.
+
+### Example7: JSON Schema Output
 
 Pass `-s`/`--json-schema` to print the shape as a real [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
 document instead of the default compact notation — composes with `-m` the same way. Note that
@@ -367,7 +401,7 @@ would produce the following output
 }
 ```
 
-### Example7: LLM-Optimized Output
+### Example8: LLM-Optimized Output
 
 Pass `-l`/`--llm` to print the shape in a compact notation with no braces, quotes, or commas —
 nesting is indentation only, array-typed fields get a trailing `[]`, and optional/union fields
@@ -439,6 +473,12 @@ For newline-delimited JSON, `analyzer.parseJsonLines(inputStream)` reads a strea
 whitespace-separated JSON values — one per line, by NDJSON convention — and merges them into a
 single shape, exactly as the CLI's `-j` flag does.
 
+To opt in to string format detection (dates, timestamps, UUIDs — off by default), construct the
+analyzer with `new JsonSchemaAnalyzer(true)` instead of the no-arg constructor. `ScalarType` then
+gains three additional values it can return for a string field — `DATE`, `DATE_TIME`, `UUID` — and
+`JsonSchemaWriter.toJsonSchema(...)` emits a matching `"format"` keyword alongside
+`"type": "string"` for them.
+
 Collections returned by `getFields()`, `getOptionalFields()`, and `getMembers()` are unmodifiable
 views. If you build shapes by hand rather than getting them from `parse()`, finish building a type
 *before* adding it to another one: `equals`/`hashCode` are derived from a type's contents, and
@@ -475,7 +515,13 @@ This project follows [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PA
   renaming a public class/method, changing a method signature, changing what `JsonType`
   permits) or to the CLI's flags/output format.
 * **MINOR** — new backward-compatible functionality: a new CLI flag, a new public method, a new
-  output mode.
+  output mode. (Note: string format detection added three new `ScalarType` constants — `DATE`,
+  `DATE_TIME`, `UUID` — which is normally a MAJOR-flagged change per the bullet above, since it
+  changes what `JsonType` permits. It ships as MINOR here because detection is strictly opt-in —
+  off by default via the no-arg `JsonSchemaAnalyzer()` constructor and the CLI's `-f` flag both
+  requiring explicit action — so no existing caller's output changes unless they opt in. Flagging
+  this explicitly since it's a judgment call on an edge case this policy didn't originally
+  anticipate.)
 * **PATCH** — backward-compatible bug fixes, documentation, internal refactors, and dependency
   bumps that don't change public behavior.
 

--- a/cli/src/main/java/io/github/ssullivan/Main.java
+++ b/cli/src/main/java/io/github/ssullivan/Main.java
@@ -69,6 +69,10 @@ public final class Main {
                 description = "Read the input as newline-delimited JSON (NDJSON), treating each value as one sample and merging them into a single shape, like -m does for a JSON array")
         private boolean jsonLines;
 
+        @CommandLine.Option(names = {"-f", "--detect-formats"},
+                description = "Detect string formats (date, date-time, uuid) instead of reporting every string as the generic \"string\" type")
+        private boolean detectFormats;
+
         @CommandLine.Option(names = {"-s", "--json-schema"},
                 description = "Print the shape as a JSON Schema (draft-07) document instead of the default compact notation")
         boolean jsonSchema;
@@ -84,7 +88,7 @@ public final class Main {
             }
 
             try (InputStream inputStream = file != null ? new FileInputStream(file) : System.in) {
-                JsonSchemaAnalyzer analyzer = new JsonSchemaAnalyzer();
+                JsonSchemaAnalyzer analyzer = new JsonSchemaAnalyzer(detectFormats);
 
                 if (jsonLines) {
                     return analyzer.parseJsonLines(inputStream);

--- a/cli/src/test/java/io/github/ssullivan/MainTest.java
+++ b/cli/src/test/java/io/github/ssullivan/MainTest.java
@@ -88,6 +88,76 @@ class MainTest {
     }
 
     @Test
+    void testDetectFormatsFlagDetectsDate(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir, "{\"createdAt\": \"2023-01-15\"}");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-f");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(ScalarType.DATE, ((ObjectType) result).getFields().get("createdAt"));
+    }
+
+    @Test
+    void testWithoutDetectFormatsFlagStringsStayPlain(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir, "{\"createdAt\": \"2023-01-15\"}");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString());
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(ScalarType.STRING, ((ObjectType) result).getFields().get("createdAt"));
+    }
+
+    @Test
+    void testDetectFormatsFlagComposesWithMergeFlag(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"createdAt\": \"2023-01-15\"}, {\"createdAt\": \"not a date\"}]");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-f", "-m");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        // Merged samples disagree on the field's format, so it falls back to plain "string"
+        // rather than reporting a date|string union
+        assertEquals(ScalarType.STRING, ((ObjectType) result).getFields().get("createdAt"));
+    }
+
+    @Test
+    void testDetectFormatsFlagComposesWithJsonSchemaFlag(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir, "{\"createdAt\": \"2023-01-15\"}");
+
+        Main.JsonSchemaAnalyzeCommand command = new Main.JsonSchemaAnalyzeCommand();
+        CommandLine commandLine = new CommandLine(command);
+        int exitCode = commandLine.execute("-i", file.toString(), "-f", "-s");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(result);
+        assertEquals("date", schema.get("properties").get("createdAt").get("format").asText());
+    }
+
+    @Test
+    void testDetectFormatsFlagParsesWithoutAffectingCallResultWhenCombinedWithLlm(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir, "{\"createdAt\": \"2023-01-15\"}");
+
+        Main.JsonSchemaAnalyzeCommand command = new Main.JsonSchemaAnalyzeCommand();
+        CommandLine commandLine = new CommandLine(command);
+        int exitCode = commandLine.execute("-i", file.toString(), "-f", "-l");
+
+        assertEquals(0, exitCode);
+        assertTrue(command.llm);
+        assertEquals(ObjectType.of("createdAt", ScalarType.DATE), commandLine.getExecutionResult());
+    }
+
+    @Test
     void testMergeFlagOnNonArrayRootLeavesResultUnchanged(@TempDir Path tempDir) throws IOException {
         Path file = writeJson(tempDir, "{\"id\": 1}");
 

--- a/core/src/main/java/io/github/ssullivan/analyze/JsonSchemaAnalyzer.java
+++ b/core/src/main/java/io/github/ssullivan/analyze/JsonSchemaAnalyzer.java
@@ -16,12 +16,30 @@ import java.util.Objects;
 public class JsonSchemaAnalyzer {
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
+    private final boolean detectFormats;
+
     /**
-     * Creates an analyzer. Instances hold no state, so one can be reused across documents and
-     * shared between threads.
+     * Creates an analyzer with string format detection off. Instances are immutable and
+     * thread-safe, so one can be reused across documents and shared between threads.
      */
     public JsonSchemaAnalyzer() {
+        this(false);
+    }
 
+    /**
+     * Creates an analyzer, optionally opting in to string format detection. Instances are
+     * immutable and thread-safe, so one can be reused across documents and shared between
+     * threads.
+     *
+     * @param detectFormats when {@code true}, string values are checked against
+     *                      {@link StringFormatDetector} and may come back as
+     *                      {@link ScalarType#DATE}, {@link ScalarType#DATE_TIME}, or
+     *                      {@link ScalarType#UUID} instead of the generic {@link ScalarType#STRING}.
+     *                      Off by default (the no-arg constructor) so existing callers' output
+     *                      is unaffected unless they opt in.
+     */
+    public JsonSchemaAnalyzer(boolean detectFormats) {
+        this.detectFormats = detectFormats;
     }
 
     /**
@@ -85,7 +103,7 @@ public class JsonSchemaAnalyzer {
         }
     }
 
-    private static JsonType parseRootValue(JsonParser jParser, JsonToken currentToken) throws IOException {
+    private JsonType parseRootValue(JsonParser jParser, JsonToken currentToken) throws IOException {
         if (currentToken == JsonToken.START_OBJECT) {
             ObjectType root = new ObjectType();
             handleObjectStruct(jParser, root);
@@ -99,7 +117,7 @@ public class JsonSchemaAnalyzer {
         }
     }
 
-    private static void handleObjectStruct(JsonParser jParser, ObjectType objectType) throws IOException {
+    private void handleObjectStruct(JsonParser jParser, ObjectType objectType) throws IOException {
         while (jParser.nextToken() != JsonToken.END_OBJECT) {
             JsonToken currentToken = jParser.currentToken();
             String name = jParser.currentName();
@@ -124,7 +142,7 @@ public class JsonSchemaAnalyzer {
         }
     }
 
-    private static ArrayType handleObjectArray(JsonParser jParser) throws IOException {
+    private ArrayType handleObjectArray(JsonParser jParser) throws IOException {
         ArrayType arrayType = new ArrayType();
         while (jParser.nextToken() != JsonToken.END_ARRAY) {
             JsonToken currentToken = jParser.currentToken();
@@ -152,7 +170,7 @@ public class JsonSchemaAnalyzer {
      * @param jsonToken a non-null {@link JsonToken}
      * @return the {@link ScalarType} matching the token
      */
-    private static JsonType convertScalarToken(JsonParser jParser, JsonToken jsonToken) {
+    private JsonType convertScalarToken(JsonParser jParser, JsonToken jsonToken) throws IOException {
         if (jsonToken == null) {
             throw new NullPointerException("JsonToken must not be null");
         }
@@ -161,7 +179,7 @@ public class JsonSchemaAnalyzer {
             case VALUE_TRUE, VALUE_FALSE -> ScalarType.BOOLEAN;
             case VALUE_NUMBER_FLOAT -> ScalarType.FLOAT;
             case VALUE_NUMBER_INT -> ScalarType.INTEGER;
-            case VALUE_STRING -> ScalarType.STRING;
+            case VALUE_STRING -> detectFormats ? StringFormatDetector.detect(jParser.getText()) : ScalarType.STRING;
             case VALUE_NULL -> ScalarType.NULL;
             default -> throw JsonSchemaAnalysisException.unsupportedScalarToken(jsonToken, jParser.currentLocation());
         };

--- a/core/src/main/java/io/github/ssullivan/analyze/SchemaMerger.java
+++ b/core/src/main/java/io/github/ssullivan/analyze/SchemaMerger.java
@@ -37,6 +37,9 @@ public final class SchemaMerger {
         if (isNumberish(a) && isNumberish(b)) {
             return ScalarType.NUMBER;
         }
+        if (isStringish(a) && isStringish(b)) {
+            return ScalarType.STRING;
+        }
         if (a instanceof ObjectType oa && b instanceof ObjectType ob) {
             return mergeObjects(oa, ob);
         }
@@ -75,6 +78,7 @@ public final class SchemaMerger {
         Set<JsonType> elements = new LinkedHashSet<>(aa.getFields());
         elements.addAll(ab.getFields());
         collapseNumbers(elements);
+        collapseStrings(elements);
 
         ArrayType result = new ArrayType();
         elements.forEach(result::addField);
@@ -86,6 +90,7 @@ public final class SchemaMerger {
         addFlattened(members, a);
         addFlattened(members, b);
         collapseNumbers(members);
+        collapseStrings(members);
 
         if (members.size() == 1) {
             return members.iterator().next();
@@ -110,5 +115,17 @@ public final class SchemaMerger {
 
     private static boolean isNumberish(JsonType type) {
         return type == ScalarType.INTEGER || type == ScalarType.FLOAT || type == ScalarType.NUMBER;
+    }
+
+    private static void collapseStrings(Set<JsonType> types) {
+        if (types.stream().filter(SchemaMerger::isStringish).count() > 1) {
+            types.removeIf(SchemaMerger::isStringish);
+            types.add(ScalarType.STRING);
+        }
+    }
+
+    private static boolean isStringish(JsonType type) {
+        return type == ScalarType.STRING || type == ScalarType.DATE
+                || type == ScalarType.DATE_TIME || type == ScalarType.UUID;
     }
 }

--- a/core/src/main/java/io/github/ssullivan/analyze/StringFormatDetector.java
+++ b/core/src/main/java/io/github/ssullivan/analyze/StringFormatDetector.java
@@ -1,0 +1,61 @@
+package io.github.ssullivan.analyze;
+
+import io.github.ssullivan.types.ScalarType;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * Structurally classifies a JSON string value as one of the formats {@link JsonSchemaAnalyzer}
+ * can optionally detect — {@link ScalarType#DATE}, {@link ScalarType#DATE_TIME},
+ * {@link ScalarType#UUID} — or {@link ScalarType#STRING} if none match.
+ * <p>
+ * Validation is purely structural (shape, not full calendar/semantic correctness): e.g.
+ * {@code "2023-13-45"} still matches {@link ScalarType#DATE} because it has the right shape,
+ * consistent with this project's "describe the shape, don't fully validate the data" philosophy.
+ * Every pattern is fully anchored and uses only bounded, non-nested quantifiers, so none of them
+ * are vulnerable to catastrophic backtracking regardless of input length.
+ */
+final class StringFormatDetector {
+
+    /** ISO 8601 calendar date: {@code YYYY-MM-DD}. */
+    private static final Pattern DATE = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}$");
+
+    /**
+     * RFC 3339 timestamp: a {@link #DATE} shape, {@code T}/{@code t}, a time, optional
+     * fractional seconds, and a {@code Z}/{@code z} or {@code +HH:MM}/{@code -HH:MM} offset. The
+     * offset is mandatory per RFC 3339 — a bare local time with no zone info doesn't match.
+     */
+    private static final Pattern DATE_TIME = Pattern.compile(
+            "^\\d{4}-\\d{2}-\\d{2}[Tt]\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?([Zz]|[+-]\\d{2}:\\d{2})$");
+
+    /** Canonical 8-4-4-4-12 hex UUID (36 characters including hyphens), either case. */
+    private static final Pattern UUID_PATTERN = Pattern.compile(
+            "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
+
+    private StringFormatDetector() {
+    }
+
+    /**
+     * Classifies a JSON string value's format.
+     *
+     * @param value a non-null string value, as read from a {@code VALUE_STRING} token
+     * @return the matching {@link ScalarType}, or {@link ScalarType#STRING} if none of the
+     *         supported formats match
+     */
+    static ScalarType detect(String value) {
+        Objects.requireNonNull(value, "StringFormatDetector.detect: parameter `value` must not be null");
+
+        int len = value.length();
+        if (len == 10 && DATE.matcher(value).matches()) {
+            return ScalarType.DATE;
+        }
+        if (len >= 20 && DATE_TIME.matcher(value).matches()) {
+            return ScalarType.DATE_TIME;
+        }
+        if (len == 36 && UUID_PATTERN.matcher(value).matches()) {
+            return ScalarType.UUID;
+        }
+        return ScalarType.STRING;
+    }
+}

--- a/core/src/main/java/io/github/ssullivan/jackson/JsonSchemaWriter.java
+++ b/core/src/main/java/io/github/ssullivan/jackson/JsonSchemaWriter.java
@@ -57,6 +57,10 @@ public final class JsonSchemaWriter {
     private static ObjectNode scalarSchema(ScalarType scalarType) {
         ObjectNode node = JsonNodeFactory.instance.objectNode();
         node.put("type", jsonSchemaTypeName(scalarType));
+        String format = jsonSchemaFormat(scalarType);
+        if (format != null) {
+            node.put("format", format);
+        }
         return node;
     }
 
@@ -102,8 +106,10 @@ public final class JsonSchemaWriter {
     private static ObjectNode unionSchema(UnionType unionType) {
         Set<JsonType> members = unionType.getMembers();
         boolean allScalar = members.stream().allMatch(member -> member instanceof ScalarType);
+        boolean anyFormatted = members.stream()
+                .anyMatch(member -> member instanceof ScalarType st && jsonSchemaFormat(st) != null);
 
-        if (allScalar) {
+        if (allScalar && !anyFormatted) {
             ObjectNode node = JsonNodeFactory.instance.objectNode();
             ArrayNode typeNode = node.putArray("type");
             members.stream()
@@ -114,8 +120,9 @@ public final class JsonSchemaWriter {
             return node;
         }
 
-        // At least one member is an object/array, which needs a full sub-schema rather than a
-        // bare type name.
+        // At least one member is an object/array (needs a full sub-schema rather than a bare
+        // type name) or carries a format that the flattened "type": [...] array can't express
+        // per-member, so every member gets its own full sub-schema instead.
         return anyOfSchema(members);
     }
 
@@ -132,10 +139,23 @@ public final class JsonSchemaWriter {
     private static String jsonSchemaTypeName(ScalarType scalarType) {
         return switch (scalarType) {
             case NULL -> "null";
-            case STRING -> "string";
+            case STRING, DATE, DATE_TIME, UUID -> "string";
             case INTEGER -> "integer";
             case FLOAT, NUMBER -> "number";
             case BOOLEAN -> "boolean";
+        };
+    }
+
+    /**
+     * @return the JSON Schema {@code format} keyword value for a detected string format, or
+     *         {@code null} for scalar types that don't carry one.
+     */
+    private static String jsonSchemaFormat(ScalarType scalarType) {
+        return switch (scalarType) {
+            case DATE -> "date";
+            case DATE_TIME -> "date-time";
+            case UUID -> "uuid";
+            default -> null;
         };
     }
 }

--- a/core/src/main/java/io/github/ssullivan/types/ScalarType.java
+++ b/core/src/main/java/io/github/ssullivan/types/ScalarType.java
@@ -1,15 +1,23 @@
 package io.github.ssullivan.types;
 
 /**
- * The JSON scalar value kinds: strings, numbers (integer/float, plus {@link #NUMBER} for a
- * merged integer/float produced by {@link io.github.ssullivan.analyze.SchemaMerger}),
- * booleans, and null.
+ * The JSON scalar value kinds: strings (plus {@link #DATE}, {@link #DATE_TIME}, and
+ * {@link #UUID} for a string recognized as one of those formats — only produced when
+ * {@link io.github.ssullivan.analyze.JsonSchemaAnalyzer} is constructed with format detection
+ * enabled), numbers (integer/float, plus {@link #NUMBER} for a merged integer/float produced by
+ * {@link io.github.ssullivan.analyze.SchemaMerger}), booleans, and null.
  */
 public enum ScalarType implements JsonType {
     /** JSON {@code null}. */
     NULL("null"),
     /** A JSON string. */
     STRING("string"),
+    /** An ISO 8601 calendar date ({@code YYYY-MM-DD}), detected only with format detection on. */
+    DATE("date"),
+    /** An RFC 3339 timestamp, detected only with format detection on. */
+    DATE_TIME("date-time"),
+    /** A canonical 8-4-4-4-12 hex UUID, detected only with format detection on. */
+    UUID("uuid"),
     /** A JSON number with no fractional part. */
     INTEGER("integer"),
     /** A JSON number with a fractional part. */

--- a/core/src/test/java/io/github/ssullivan/JsonSchemaAnalyzerTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonSchemaAnalyzerTest.java
@@ -343,9 +343,63 @@ class JsonSchemaAnalyzerTest {
         assertTrue(exception.getMessage().contains("line 2"), exception.getMessage());
     }
 
+    @Test
+    void testFormatDetectionOffByDefaultLeavesDateLikeStringsPlain() throws IOException {
+        assertEquals(ScalarType.STRING, inferSchema("\"2023-01-15\""));
+    }
+
+    @Test
+    void testFormatDetectionOnDetectsDate() throws IOException {
+        assertEquals(ScalarType.DATE, inferSchema("\"2023-01-15\"", true));
+    }
+
+    @Test
+    void testFormatDetectionOnDetectsDateTime() throws IOException {
+        assertEquals(ScalarType.DATE_TIME, inferSchema("\"2023-01-15T10:30:00Z\"", true));
+    }
+
+    @Test
+    void testFormatDetectionOnDetectsUuid() throws IOException {
+        assertEquals(ScalarType.UUID, inferSchema("\"550e8400-e29b-41d4-a716-446655440000\"", true));
+    }
+
+    @Test
+    void testFormatDetectionOnLeavesPlainStringsAlone() throws IOException {
+        assertEquals(ScalarType.STRING, inferSchema("\"hello\"", true));
+    }
+
+    @Test
+    void testFormatDetectionAppliesInsideNestedObjectsAndArrays() throws IOException {
+        String json = "{\"events\": [\"2023-01-15\", \"2023-02-20\"]}";
+
+        JsonType schema = inferSchema(json, true);
+
+        assertEquals(
+                ObjectType.of("events", ArrayType.of(ScalarType.DATE)),
+                schema
+        );
+    }
+
+    @Test
+    void testFormatDetectionAppliesInJsonLinesMode() throws IOException {
+        String ndjson = String.join("\n",
+                "{\"created\": \"2023-01-15\"}",
+                "{\"created\": \"2023-02-20\"}");
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("created", ScalarType.DATE), schema);
+        }
+    }
+
     private JsonType inferSchema(String json) throws IOException {
+        return inferSchema(json, false);
+    }
+
+    private JsonType inferSchema(String json, boolean detectFormats) throws IOException {
         try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
-            JsonSchemaAnalyzer jsonSchemaAnalyzer = new JsonSchemaAnalyzer();
+            JsonSchemaAnalyzer jsonSchemaAnalyzer = new JsonSchemaAnalyzer(detectFormats);
             return jsonSchemaAnalyzer.parse(inputStream);
         }
     }

--- a/core/src/test/java/io/github/ssullivan/JsonSchemaWriterTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonSchemaWriterTest.java
@@ -140,6 +140,83 @@ class JsonSchemaWriterTest {
     }
 
     @Test
+    void testDateScalarEmitsTypeAndFormat() {
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(ScalarType.DATE);
+
+        assertEquals("string", schema.get("type").asText());
+        assertEquals("date", schema.get("format").asText());
+    }
+
+    @Test
+    void testDateTimeScalarEmitsTypeAndFormat() {
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(ScalarType.DATE_TIME);
+
+        assertEquals("string", schema.get("type").asText());
+        assertEquals("date-time", schema.get("format").asText());
+    }
+
+    @Test
+    void testUuidScalarEmitsTypeAndFormat() {
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(ScalarType.UUID);
+
+        assertEquals("string", schema.get("type").asText());
+        assertEquals("uuid", schema.get("format").asText());
+    }
+
+    @Test
+    void testPlainStringScalarOmitsFormat() {
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(ScalarType.STRING);
+
+        assertFalse(schema.has("format"));
+    }
+
+    @Test
+    void testUnionOfPlainScalarsStillUsesTypeArray() {
+        // Regression guard: nothing formatted -> the compact "type": [...] fast path is untouched
+        UnionType unionType = new UnionType(Set.of(ScalarType.INTEGER, ScalarType.STRING));
+
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(unionType);
+
+        assertTrue(schema.get("type").isArray());
+        assertFalse(schema.has("anyOf"));
+    }
+
+    @Test
+    void testUnionOfFormattedAndPlainScalarUsesAnyOfNotTypeArray() {
+        UnionType unionType = new UnionType(Set.of(ScalarType.DATE, ScalarType.INTEGER));
+
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(unionType);
+
+        assertFalse(schema.has("type"));
+        assertTrue(schema.get("anyOf").isArray());
+        assertEquals(2, schema.get("anyOf").size());
+
+        boolean anyMemberHasDateFormat = false;
+        for (var member : schema.get("anyOf")) {
+            if (member.has("format") && "date".equals(member.get("format").asText())) {
+                anyMemberHasDateFormat = true;
+            }
+        }
+        assertTrue(anyMemberHasDateFormat);
+    }
+
+    @Test
+    void testUnionOfTwoDifferentFormatsUsesAnyOf() {
+        UnionType unionType = new UnionType(Set.of(ScalarType.DATE, ScalarType.UUID));
+
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(unionType);
+
+        assertTrue(schema.get("anyOf").isArray());
+        assertEquals(2, schema.get("anyOf").size());
+
+        List<String> formats = new ArrayList<>();
+        for (var member : schema.get("anyOf")) {
+            formats.add(member.get("format").asText());
+        }
+        assertEquals(Set.of("date", "uuid"), Set.copyOf(formats));
+    }
+
+    @Test
     void testToJsonSchemaRejectsNull() {
         assertThrows(NullPointerException.class, () -> JsonSchemaWriter.toJsonSchema(null));
     }

--- a/core/src/test/java/io/github/ssullivan/SchemaMergerTest.java
+++ b/core/src/test/java/io/github/ssullivan/SchemaMergerTest.java
@@ -117,6 +117,59 @@ class SchemaMergerTest {
     }
 
     @Test
+    void testDifferentStringFormatsCollapseToString() {
+        ObjectType a = ObjectType.of("x", ScalarType.DATE);
+        ObjectType b = ObjectType.of("x", ScalarType.UUID);
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(ObjectType.of("x", ScalarType.STRING), merged);
+    }
+
+    @Test
+    void testFormattedStringAndPlainStringCollapseToString() {
+        ObjectType a = ObjectType.of("x", ScalarType.DATE);
+        ObjectType b = ObjectType.of("x", ScalarType.STRING);
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(ObjectType.of("x", ScalarType.STRING), merged);
+    }
+
+    @Test
+    void testStringFormatDoesNotCollapseAgainstNonStringTypes() {
+        ObjectType a = ObjectType.of("x", ScalarType.DATE);
+        ObjectType b = ObjectType.of("x", ScalarType.INTEGER);
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertInstanceOf(ObjectType.class, merged);
+        JsonType xType = ((ObjectType) merged).getFields().get("x");
+        assertInstanceOf(UnionType.class, xType);
+        assertEquals(Set.of(ScalarType.DATE, ScalarType.INTEGER), ((UnionType) xType).getMembers());
+    }
+
+    @Test
+    void testMergingArraysWithConflictingStringFormatsCollapsesElements() {
+        ArrayType a = ArrayType.of(ScalarType.DATE);
+        ArrayType b = ArrayType.of(ScalarType.UUID);
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(ArrayType.of(ScalarType.STRING), merged);
+    }
+
+    @Test
+    void testSameStringFormatOnBothSidesStaysThatFormat() {
+        ObjectType a = ObjectType.of("x", ScalarType.DATE);
+        ObjectType b = ObjectType.of("x", ScalarType.DATE);
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(ObjectType.of("x", ScalarType.DATE), merged);
+    }
+
+    @Test
     void testMergeRejectsNullArguments() {
         assertThrows(NullPointerException.class, () -> SchemaMerger.merge(null, ScalarType.STRING));
         assertThrows(NullPointerException.class, () -> SchemaMerger.merge(ScalarType.STRING, null));

--- a/core/src/test/java/io/github/ssullivan/analyze/StringFormatDetectorTest.java
+++ b/core/src/test/java/io/github/ssullivan/analyze/StringFormatDetectorTest.java
@@ -1,0 +1,92 @@
+package io.github.ssullivan.analyze;
+
+import io.github.ssullivan.types.ScalarType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class StringFormatDetectorTest {
+
+    @Test
+    void testDetectsValidDate() {
+        assertEquals(ScalarType.DATE, StringFormatDetector.detect("2023-01-15"));
+    }
+
+    @Test
+    void testDetectsValidDateTimeWithUppercaseZ() {
+        assertEquals(ScalarType.DATE_TIME, StringFormatDetector.detect("2023-01-15T10:30:00Z"));
+    }
+
+    @Test
+    void testDetectsValidDateTimeWithLowercaseTAndZ() {
+        assertEquals(ScalarType.DATE_TIME, StringFormatDetector.detect("2023-01-15t10:30:00z"));
+    }
+
+    @Test
+    void testDetectsValidDateTimeWithFractionalSeconds() {
+        assertEquals(ScalarType.DATE_TIME, StringFormatDetector.detect("2023-01-15T10:30:00.123456Z"));
+    }
+
+    @Test
+    void testDetectsValidDateTimeWithPositiveOffset() {
+        assertEquals(ScalarType.DATE_TIME, StringFormatDetector.detect("2023-01-15T10:30:00+05:30"));
+    }
+
+    @Test
+    void testDetectsValidDateTimeWithNegativeOffset() {
+        assertEquals(ScalarType.DATE_TIME, StringFormatDetector.detect("2023-01-15T10:30:00-08:00"));
+    }
+
+    @Test
+    void testDetectsLowercaseUuid() {
+        assertEquals(ScalarType.UUID, StringFormatDetector.detect("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    @Test
+    void testDetectsUppercaseUuid() {
+        assertEquals(ScalarType.UUID, StringFormatDetector.detect("550E8400-E29B-41D4-A716-446655440000"));
+    }
+
+    @Test
+    void testPlainStringIsNotDetected() {
+        assertEquals(ScalarType.STRING, StringFormatDetector.detect("hello world"));
+    }
+
+    @Test
+    void testDateWithSlashSeparatorsIsNotDetected() {
+        assertEquals(ScalarType.STRING, StringFormatDetector.detect("2023/01/15"));
+    }
+
+    @Test
+    void testDateTimeMissingOffsetIsNotDetected() {
+        // RFC 3339 requires an offset; a bare local time with no zone info isn't a match
+        assertEquals(ScalarType.STRING, StringFormatDetector.detect("2023-01-15T10:30:00"));
+    }
+
+    @Test
+    void testUuidMissingHyphensIsNotDetected() {
+        assertEquals(ScalarType.STRING, StringFormatDetector.detect("550e8400e29b41d4a716446655440000"));
+    }
+
+    @Test
+    void testUuidWrongGroupLengthIsNotDetected() {
+        assertEquals(ScalarType.STRING, StringFormatDetector.detect("550e840-e29b-41d4-a716-446655440000"));
+    }
+
+    @Test
+    void testEmptyStringIsNotDetected() {
+        assertEquals(ScalarType.STRING, StringFormatDetector.detect(""));
+    }
+
+    @Test
+    void testDateStructurallyValidButCalendarInvalidStillDetected() {
+        // No calendar validation is performed by design -- shape, not semantic correctness
+        assertEquals(ScalarType.DATE, StringFormatDetector.detect("2023-13-45"));
+    }
+
+    @Test
+    void testDetectRejectsNull() {
+        assertThrows(NullPointerException.class, () -> StringFormatDetector.detect(null));
+    }
+}


### PR DESCRIPTION
## Summary

#7 (string format detection) was stacked on #6's branch so its diff would show only the format-detection changes. #6 has since merged into `main`, but GitHub doesn't auto-retarget a stacked PR's base branch when the PR it's stacked on merges — so #7 actually merged into `claude/json-schema-analyzer-improvements-dcvh6g` (at the state #6 left it in), not into `main`. Net effect: the format-detection commit never made it onto `main`.

This PR carries that same content (2 commits: the format-detection commit + its merge commit from #7) directly onto `main` to close the gap. No new changes — see #7 for the full description and test plan.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAJqLraEZMGqPR5QVfXiwa)_