### PR TITLE
Add opt-in enum detection for low-cardinality string fields

### DIFF
--- a/.agents/skills/json-shape/SKILL.md
+++ b/.agents/skills/json-shape/SKILL.md
@@ -20,6 +20,9 @@ reading the whole payload into context.
   merged shape showing which fields are optional and which vary in type.
 - Field values look like dates, timestamps, or UUIDs and you want that reflected in the output
   instead of everything reported as a generic string.
+- A string field only ever takes a handful of distinct values (≤5) — e.g. a status or category
+  field — and you want that reflected as an enum of the exact values instead of generic
+  `string`.
 - You need a real JSON Schema (draft-07) document to hand to a validator or code generator.
 
 ## Usage
@@ -46,6 +49,7 @@ own — choose them using the guidance below.
 | `-m`, `--merge-samples` | The input is a top-level *array of sample records* rather than one document. Folds them into a single shape: fields missing from some samples get `?`, fields whose type varies become a `\|` union. |
 | `-j`, `--jsonl` | The input is newline-delimited JSON (NDJSON) — one JSON value per line — instead of a single document or array. Merges the values the same way `-m` merges array elements; `-m` itself has no effect when `-j` is set. |
 | `-f`, `--detect-formats` | String values may be dates (`YYYY-MM-DD`), timestamps (RFC 3339), or UUIDs, and you want that reflected in the output instead of everything reported as generic `string`. Off by default. |
+| `-e`, `--detect-enums` | A string field only ever takes a handful of distinct values (≤5) and you want the exact values reported instead of generic `string`. A 6th distinct value falls back to plain `string`, as does a field holding just one value. Works at any depth, including inside arrays; combine with `-m`/`-j` to pool values across samples. Add `-f` too if date/UUID-shaped values should be reported as `date`/`uuid` rather than as enum values. Off by default. |
 | `-s`, `--json-schema` | Only when a real JSON Schema document is explicitly wanted. Much more verbose than `-l`. |
 | *(none)* | The default JSON-shaped compact notation. Prefer `-l` unless you specifically want valid JSON out. |
 
@@ -106,7 +110,18 @@ id: uuid
 note: string
 ```
 
-The `-l` notation is specified in full in the project README's "Example8: LLM-Optimized
+Detecting low-cardinality enum fields across merged samples:
+
+```shell
+bash scripts/analyze.sh -l -m -e -i tickets.json
+```
+
+```
+id: integer
+status: closed|open|pending
+```
+
+The `-l` notation is specified in full in the project README's "Example9: LLM-Optimized
 Output" section.
 
 ## Requirements and troubleshooting
@@ -118,6 +133,6 @@ The script prefers a locally-built jar, searching upward from the current direct
 released jar to `~/.cache/json-schema-analyzer/` (override with `JSON_SCHEMA_ANALYZER_CACHE`)
 and reuses it on later runs.
 
-If you see `Unknown option: '-l'` (or `-m`/`-j`/`-f`/`-s`), the jar being used predates that
+If you see `Unknown option: '-l'` (or `-m`/`-j`/`-f`/`-e`/`-s`), the jar being used predates that
 flag — almost always the downloaded release rather than a local build. Building the repo locally
 (`mvn clean install`) makes the script prefer that fresh jar instead.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ java -jar json-schema-analyzer-<version>.jar -i example.json
 * [Build](#build)
 * [CLI](#cli)
 * [Examples](#examples)
-  * [Example8: LLM-Optimized Output](#example8-llm-optimized-output)
+  * [Example9: LLM-Optimized Output](#example9-llm-optimized-output)
 * [Error Handling](#error-handling)
 * [Using as a Library](#using-as-a-library)
 * [Agent Skills](#agent-skills)
@@ -115,18 +115,23 @@ To build a native binary yourself, use a [GraalVM](https://www.graalvm.org/) JDK
 
 ## CLI 
 ```shell
-Usage: json-analyze [-fhjlmsV] [-i=<file>]
+Usage: json-analyze [-efhjlmsV] [-i=<file>]
 Describes the fields and datatypes in a JSON document.
+  -e, --detect-enums        Detect low-cardinality string fields (<= 5 distinct
+                              values) and report them as an enum of the
+                              observed values, instead of the generic "string"
+                              type. A field with more distinct values falls
+                              back to plain "string"
   -f, --detect-formats      Detect string formats (date, date-time, uuid)
                               instead of reporting every string as the generic
                               "string" type
   -h, --help                Show this help message and exit.
   -i, --input-file=<file>   The JSON file to analyze; reads from stdin if
                               omitted
-  -j, --jsonl                Read the input as newline-delimited JSON (NDJSON),
+  -j, --jsonl               Read the input as newline-delimited JSON (NDJSON),
                               treating each value as one sample and merging
-                              them into a single shape, like -m does for a
-                              JSON array
+                              them into a single shape, like -m does for a JSON
+                              array
   -l, --llm                 Print the shape in a compact, punctuation-free
                               notation designed to be pasted into an LLM prompt
                               cheaply, instead of the default compact notation
@@ -348,7 +353,69 @@ disagree on which format — the field falls back to the generic `string` type r
 reporting a `date|uuid`-style union, since knowing *a* format was ambiguous is more useful than
 an unreadable mix.
 
-### Example7: JSON Schema Output
+### Example7: Enum Detection
+
+Pass `-e`/`--detect-enums` to have a string field that only ever takes a handful of distinct
+values reported as an enum of those exact values, instead of the generic `string` type. Off by
+default. It composes with `-m`/`-j` to pool values across samples, but works on a single document
+too.
+
+```shell
+cat <<EOF >tickets.json
+[
+  {"id": 1, "status": "open"},
+  {"id": 2, "status": "closed"},
+  {"id": 3, "status": "pending"},
+  {"id": 4, "status": "open"}
+]
+EOF
+java -jar json-schema-analyzer-<version>.jar -i tickets.json -m -e
+```
+
+would produce the following output
+
+```json
+{
+  "id" : "integer",
+  "status" : "closed|open|pending"
+}
+```
+
+A field is only reported as an enum while it holds 5 or fewer distinct values — a 6th distinct
+value falls back to plain `string`, with no literal values shown. A field that happens to hold
+the same single value everywhere is reported as plain `string`, not a one-value enum; only
+genuine variation across 2 or more values is reported.
+
+Detection applies at any depth, and every element of an array shares one position, so their
+values pool together. That means it works for fields of objects inside an array, and for bare
+arrays of strings:
+
+```shell
+echo '{"tags": ["a", "b", "a"], "items": [{"k": "x"}, {"k": "y"}]}' \
+  | java -jar json-schema-analyzer-<version>.jar -e -l
+```
+
+```
+items[]:
+  k: x|y
+tags[]: a|b
+```
+
+**Add `-f` if you don't want date-like or UUID-like values reported as enum values.** On its own,
+`-e` has no notion of those formats, so a `"2023-06-01"` field with a handful of distinct values
+is reported as an enum of those dates. With `-f` also passed, such a field is recognized as
+`date`/`date-time`/`uuid` and left alone, since those aren't categorical values — and a field
+that is a date in only *some* samples reports as plain `string` rather than an enum built from
+the rest. A field that varies in type across samples (`integer|string`, say) likewise gets no
+enum.
+
+Enum values are printed as-is, so a value containing `|` is escaped (`a\|b`) to keep it distinct
+from the separator. One ambiguity remains by design: a value that happens to *be* a type name —
+an enum of `"string"` and `"integer"`, say — renders as `integer|string`, which reads the same as
+a genuine integer-or-string union. Use `-s` if you need that distinction; its `enum` array is a
+real JSON array and is never ambiguous.
+
+### Example8: JSON Schema Output
 
 Pass `-s`/`--json-schema` to print the shape as a real [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
 document instead of the default compact notation — composes with `-m` the same way. Note that
@@ -401,7 +468,7 @@ would produce the following output
 }
 ```
 
-### Example8: LLM-Optimized Output
+### Example9: LLM-Optimized Output
 
 Pass `-l`/`--llm` to print the shape in a compact notation with no braces, quotes, or commas —
 nesting is indentation only, array-typed fields get a trailing `[]`, and optional/union fields
@@ -463,11 +530,11 @@ if (schema instanceof ObjectType objectType) {
 }
 ```
 
-`JsonType` is a sealed interface (`ObjectType`, `ArrayType`, `ScalarType`, `UnionType`), so callers
-can pattern-match on it directly. `SchemaMerger.merge(a, b)` is available the same way for folding
-multiple samples into one shape, exactly as the CLI's `-m` flag does internally. To render a shape
-the way the CLI does, use `Json.write(schema)` for the compact notation or
-`JsonSchemaWriter.toJsonSchema(schema)` for a draft-07 document.
+`JsonType` is a sealed interface (`ObjectType`, `ArrayType`, `ScalarType`, `EnumType`,
+`UnionType`), so callers can pattern-match on it directly. `SchemaMerger.merge(a, b)` is
+available the same way for folding multiple samples into one shape, exactly as the CLI's `-m`
+flag does internally. To render a shape the way the CLI does, use `Json.write(schema)` for the
+compact notation or `JsonSchemaWriter.toJsonSchema(schema)` for a draft-07 document.
 
 For newline-delimited JSON, `analyzer.parseJsonLines(inputStream)` reads a stream of
 whitespace-separated JSON values — one per line, by NDJSON convention — and merges them into a
@@ -478,6 +545,19 @@ analyzer with `new JsonSchemaAnalyzer(true)` instead of the no-arg constructor. 
 gains three additional values it can return for a string field — `DATE`, `DATE_TIME`, `UUID` — and
 `JsonSchemaWriter.toJsonSchema(...)` emits a matching `"format"` keyword alongside
 `"type": "string"` for them.
+
+To opt in to enum detection (off by default), pass `true` as the second constructor argument —
+e.g. `new JsonSchemaAnalyzer(false, true)`. A position holding between 2 and 5 distinct string
+values comes back as an `EnumType` of them instead of the generic `ScalarType.STRING`; one
+holding more, or holding a single value, or whose values are sometimes a detected
+`DATE`/`DATE_TIME`/`UUID`, stays `ScalarType.STRING`. Values are collected per position and
+substituted in only once the shape is final, so detection works at any depth — including inside
+arrays, whose elements share one position and pool their values.
+
+`analyzer.parseSamples(inputStream)` is what the CLI's `-m` flag calls: it treats each element of
+a top-level array as one sample and merges them, streaming rather than building an intermediate
+`ArrayType`, so cost stays linear in the number of samples. Input whose root isn't an array is
+described as the single document it is, exactly as `parse()` would.
 
 Collections returned by `getFields()`, `getOptionalFields()`, and `getMembers()` are unmodifiable
 views. If you build shapes by hand rather than getting them from `parse()`, finish building a type
@@ -521,7 +601,10 @@ This project follows [Semantic Versioning](https://semver.org/): `MAJOR.MINOR.PA
   off by default via the no-arg `JsonSchemaAnalyzer()` constructor and the CLI's `-f` flag both
   requiring explicit action — so no existing caller's output changes unless they opt in. Flagging
   this explicitly since it's a judgment call on an edge case this policy didn't originally
-  anticipate.)
+  anticipate. Enum detection similarly adds a new `EnumType` implementation to what `JsonType`
+  permits — also normally a MAJOR change per the bullet above. It ships as MINOR for the same
+  reason: strictly opt-in, off by default via the boolean `detectEnums` constructor parameter and
+  the CLI's `-e` flag both requiring explicit action.)
 * **PATCH** — backward-compatible bug fixes, documentation, internal refactors, and dependency
   bumps that don't change public behavior.
 

--- a/cli/src/main/java/io/github/ssullivan/Main.java
+++ b/cli/src/main/java/io/github/ssullivan/Main.java
@@ -1,7 +1,6 @@
 package io.github.ssullivan;
 
 import io.github.ssullivan.analyze.JsonSchemaAnalyzer;
-import io.github.ssullivan.analyze.SchemaMerger;
 import io.github.ssullivan.format.LlmWriter;
 import io.github.ssullivan.jackson.Json;
 import io.github.ssullivan.jackson.JsonSchemaWriter;
@@ -69,6 +68,10 @@ public final class Main {
                 description = "Read the input as newline-delimited JSON (NDJSON), treating each value as one sample and merging them into a single shape, like -m does for a JSON array")
         private boolean jsonLines;
 
+        @CommandLine.Option(names = {"-e", "--detect-enums"},
+                description = "Detect low-cardinality string fields (<= 5 distinct values) and report them as an enum of the observed values, instead of the generic \"string\" type. A field with more distinct values falls back to plain \"string\"")
+        private boolean detectEnums;
+
         @CommandLine.Option(names = {"-f", "--detect-formats"},
                 description = "Detect string formats (date, date-time, uuid) instead of reporting every string as the generic \"string\" type")
         private boolean detectFormats;
@@ -88,21 +91,15 @@ public final class Main {
             }
 
             try (InputStream inputStream = file != null ? new FileInputStream(file) : System.in) {
-                JsonSchemaAnalyzer analyzer = new JsonSchemaAnalyzer(detectFormats);
+                JsonSchemaAnalyzer analyzer = new JsonSchemaAnalyzer(detectFormats, detectEnums);
 
                 if (jsonLines) {
                     return analyzer.parseJsonLines(inputStream);
                 }
-
-                JsonType result = analyzer.parse(inputStream);
-
-                if (mergeSamples && result instanceof ArrayType arrayType) {
-                    return arrayType.getFields().stream()
-                            .reduce(SchemaMerger::merge)
-                            .orElse(arrayType);
+                if (mergeSamples) {
+                    return analyzer.parseSamples(inputStream);
                 }
-
-                return result;
+                return analyzer.parse(inputStream);
             }
         }
     }

--- a/cli/src/test/java/io/github/ssullivan/MainTest.java
+++ b/cli/src/test/java/io/github/ssullivan/MainTest.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -155,6 +156,115 @@ class MainTest {
         assertEquals(0, exitCode);
         assertTrue(command.llm);
         assertEquals(ObjectType.of("createdAt", ScalarType.DATE), commandLine.getExecutionResult());
+    }
+
+    @Test
+    void testDetectEnumsFlagComposesWithMergeFlag(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"status\": \"open\"}, {\"status\": \"closed\"}, {\"status\": \"pending\"}]");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-m", "-e");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        JsonType statusType = ((ObjectType) result).getFields().get("status");
+        assertInstanceOf(EnumType.class, statusType);
+        assertEquals(Set.of("open", "closed", "pending"), ((EnumType) statusType).getValues());
+    }
+
+    @Test
+    void testWithoutDetectEnumsFlagStringsStayPlain(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"status\": \"open\"}, {\"status\": \"closed\"}]");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-m");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(ScalarType.STRING, ((ObjectType) result).getFields().get("status"));
+    }
+
+    @Test
+    void testDetectEnumsFlagFallsBackToPlainStringPastCap(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"status\":\"a\"},{\"status\":\"b\"},{\"status\":\"c\"},"
+                        + "{\"status\":\"d\"},{\"status\":\"e\"},{\"status\":\"f\"}]");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-m", "-e");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(ScalarType.STRING, ((ObjectType) result).getFields().get("status"));
+    }
+
+    @Test
+    void testDetectEnumsFlagComposesWithJsonSchemaFlag(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"status\": \"open\"}, {\"status\": \"closed\"}]");
+
+        Main.JsonSchemaAnalyzeCommand command = new Main.JsonSchemaAnalyzeCommand();
+        CommandLine commandLine = new CommandLine(command);
+        int exitCode = commandLine.execute("-i", file.toString(), "-m", "-e", "-s");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(result);
+        ObjectNode statusSchema = (ObjectNode) schema.get("properties").get("status");
+        assertEquals("string", statusSchema.get("type").asText());
+        assertTrue(statusSchema.get("enum").isArray());
+        assertEquals(2, statusSchema.get("enum").size());
+    }
+
+    @Test
+    void testDetectEnumsFlagComposesWithLlmFlag(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"status\": \"open\"}, {\"status\": \"closed\"}]");
+
+        Main.JsonSchemaAnalyzeCommand command = new Main.JsonSchemaAnalyzeCommand();
+        CommandLine commandLine = new CommandLine(command);
+        int exitCode = commandLine.execute("-i", file.toString(), "-m", "-e", "-l");
+
+        assertEquals(0, exitCode);
+        assertTrue(command.llm);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(EnumType.of("open", "closed"), ((ObjectType) result).getFields().get("status"));
+    }
+
+    @Test
+    void testDetectEnumsFlagComposesWithJsonLinesFlag(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir, "{\"status\": \"open\"}\n{\"status\": \"closed\"}\n");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-j", "-e");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(EnumType.of("open", "closed"), ((ObjectType) result).getFields().get("status"));
+    }
+
+    @Test
+    void testDetectEnumsFlagAndDetectFormatsFlagComposeIndependently(@TempDir Path tempDir) throws IOException {
+        Path file = writeJson(tempDir,
+                "[{\"status\": \"open\", \"id\": \"550e8400-e29b-41d4-a716-446655440000\"}, "
+                        + "{\"status\": \"closed\", \"id\": \"6ba7b810-9dad-11d1-80b4-00c04fd430c8\"}]");
+
+        CommandLine commandLine = new CommandLine(new Main.JsonSchemaAnalyzeCommand());
+        int exitCode = commandLine.execute("-i", file.toString(), "-m", "-e", "-f");
+
+        assertEquals(0, exitCode);
+        JsonType result = commandLine.getExecutionResult();
+        assertInstanceOf(ObjectType.class, result);
+        assertEquals(EnumType.of("open", "closed"), ((ObjectType) result).getFields().get("status"));
+        assertEquals(ScalarType.UUID, ((ObjectType) result).getFields().get("id"));
     }
 
     @Test

--- a/core/src/main/java/io/github/ssullivan/analyze/JsonSchemaAnalyzer.java
+++ b/core/src/main/java/io/github/ssullivan/analyze/JsonSchemaAnalyzer.java
@@ -8,7 +8,12 @@ import io.github.ssullivan.types.*;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * The JsonSchemaAnalyzer is used to describe the schema of a single JSON document.
@@ -16,14 +21,24 @@ import java.util.Objects;
 public class JsonSchemaAnalyzer {
     private static final JsonFactory JSON_FACTORY = new JsonFactory();
 
+    /**
+     * How many distinct sample shapes {@link SampleFolder} will remember before it stops
+     * deduplicating. Bounded so that input whose samples are all structurally distinct — enum
+     * detection on a high-cardinality field, say — degrades to plain merging rather than
+     * retaining a shape per sample.
+     */
+    private static final int FOLDED_SHAPE_LIMIT = 1024;
+
     private final boolean detectFormats;
+    private final boolean detectEnums;
 
     /**
-     * Creates an analyzer with string format detection off. Instances are immutable and
-     * thread-safe, so one can be reused across documents and shared between threads.
+     * Creates an analyzer with string format detection and enum detection off. Instances are
+     * immutable and thread-safe, so one can be reused across documents and shared between
+     * threads.
      */
     public JsonSchemaAnalyzer() {
-        this(false);
+        this(false, false);
     }
 
     /**
@@ -39,7 +54,41 @@ public class JsonSchemaAnalyzer {
      *                      is unaffected unless they opt in.
      */
     public JsonSchemaAnalyzer(boolean detectFormats) {
+        this(detectFormats, false);
+    }
+
+    /**
+     * Creates an analyzer, optionally opting in to string format detection and/or enum
+     * detection. Instances are immutable and thread-safe, so one can be reused across documents
+     * and shared between threads.
+     *
+     * @param detectFormats when {@code true}, string values are checked against
+     *                      {@link StringFormatDetector} and may come back as
+     *                      {@link ScalarType#DATE}, {@link ScalarType#DATE_TIME}, or
+     *                      {@link ScalarType#UUID} instead of the generic {@link ScalarType#STRING}.
+     * @param detectEnums   when {@code true}, a string value's literal text is recorded against
+     *                      the position it was found at, and any position that ends up holding
+     *                      between two and {@link EnumType#MAX_VALUES} distinct values is
+     *                      reported as an {@link EnumType} of them rather than the generic
+     *                      {@link ScalarType#STRING}. A position holding more values than that,
+     *                      or one whose values are sometimes a detected format
+     *                      ({@link ScalarType#DATE}/{@link ScalarType#DATE_TIME}/
+     *                      {@link ScalarType#UUID}), stays {@link ScalarType#STRING}; so does one
+     *                      holding a single value, so a field that merely happens to be constant
+     *                      never has that value reported.
+     *                      <p>
+     *                      Values are collected by position rather than embedded in the shape as
+     *                      parsing goes, and substituted in only once the shape is final. Nothing
+     *                      about the shape differs while it is being built or merged, so array
+     *                      elements still deduplicate by equality and enum detection applies at
+     *                      any depth — including fields of objects inside an array, and bare
+     *                      arrays of strings, whose elements all share one position and therefore
+     *                      pool their values. Off by default so existing callers' output is
+     *                      unaffected unless they opt in.
+     */
+    public JsonSchemaAnalyzer(boolean detectFormats, boolean detectEnums) {
         this.detectFormats = detectFormats;
+        this.detectEnums = detectEnums;
     }
 
     /**
@@ -57,8 +106,9 @@ public class JsonSchemaAnalyzer {
 
         try (JsonParser jParser = JSON_FACTORY.createParser(source)) {
             try {
+                PathNode root = newRootNode();
                 jParser.nextToken();
-                return parseRootValue(jParser, jParser.currentToken());
+                return applyEnums(parseRootValue(jParser, jParser.currentToken(), root), root);
             } catch (JsonProcessingException e) {
                 throw JsonSchemaAnalysisException.malformedJson(e);
             }
@@ -87,51 +137,104 @@ public class JsonSchemaAnalyzer {
 
         try (JsonParser jParser = JSON_FACTORY.createParser(source)) {
             try {
-                JsonType merged = null;
+                PathNode root = newRootNode();
+                SampleFolder folder = new SampleFolder();
                 JsonToken token;
                 while ((token = jParser.nextToken()) != null) {
-                    JsonType value = parseRootValue(jParser, token);
-                    merged = merged == null ? value : SchemaMerger.merge(merged, value);
+                    folder.fold(parseRootValue(jParser, token, root));
                 }
+                JsonType merged = folder.result();
                 if (merged == null) {
                     throw JsonSchemaAnalysisException.unsupportedRoot(null, jParser.currentLocation());
                 }
-                return merged;
+                return applyEnums(merged, root);
             } catch (JsonProcessingException e) {
                 throw JsonSchemaAnalysisException.malformedJson(e);
             }
         }
     }
 
-    private JsonType parseRootValue(JsonParser jParser, JsonToken currentToken) throws IOException {
+    /**
+     * Creates a single merged {@link JsonType} shape from a top-level JSON array, treating each
+     * of its elements as one sample and folding them together via {@link SchemaMerger} — a field
+     * missing from some samples becomes optional, and one whose type varies across samples
+     * becomes a union. This is what the CLI's {@code -m} flag calls.
+     * <p>
+     * Each element is parsed as an independent sample rather than accumulated as an array
+     * element, which matters in two ways: enum detection applies to a sample's own fields (see
+     * the {@code detectEnums} constructor parameter), and merging stays linear in the number of
+     * samples because no intermediate {@link ArrayType} of per-sample shapes is ever built.
+     * <p>
+     * Input whose root is not an array has no samples to merge, so it is described as the single
+     * document it is, exactly as {@link #parse} would. An empty array yields an empty
+     * {@link ArrayType}.
+     *
+     * @param source a non-null {@link InputStream} that contains JSON
+     * @return the merged shape of every element, or the document's own shape if its root is not
+     *         an array
+     * @throws IOException                if the source itself cannot be read (a genuine I/O
+     *                                     failure)
+     * @throws JsonSchemaAnalysisException if the source can be read but its content isn't
+     *                                     analyzable (malformed or unsupported JSON)
+     */
+    public JsonType parseSamples(InputStream source) throws IOException {
+        Objects.requireNonNull(source, "The method parameter `source` must not be null");
+
+        try (JsonParser jParser = JSON_FACTORY.createParser(source)) {
+            try {
+                PathNode root = newRootNode();
+                jParser.nextToken();
+                JsonToken currentToken = jParser.currentToken();
+                if (currentToken != JsonToken.START_ARRAY) {
+                    return applyEnums(parseRootValue(jParser, currentToken, root), root);
+                }
+
+                SampleFolder folder = new SampleFolder();
+                while (jParser.nextToken() != JsonToken.END_ARRAY) {
+                    folder.fold(parseRootValue(jParser, jParser.currentToken(), root));
+                }
+                JsonType merged = folder.result();
+                return merged == null ? new ArrayType() : applyEnums(merged, root);
+            } catch (JsonProcessingException e) {
+                throw JsonSchemaAnalysisException.malformedJson(e);
+            }
+        }
+    }
+
+    private JsonType parseRootValue(JsonParser jParser, JsonToken currentToken, PathNode node) throws IOException {
         if (currentToken == JsonToken.START_OBJECT) {
             ObjectType root = new ObjectType();
-            handleObjectStruct(jParser, root);
+            handleObjectStruct(jParser, root, node);
             return root;
         } else if (currentToken == JsonToken.START_ARRAY) {
-            return handleObjectArray(jParser);
+            return handleObjectArray(jParser, node);
         } else if (currentToken != null && currentToken.isScalarValue()) {
-            return convertScalarToken(jParser, currentToken);
+            return convertScalarToken(jParser, currentToken, node);
         } else {
             throw JsonSchemaAnalysisException.unsupportedRoot(currentToken, jParser.currentLocation());
         }
     }
 
-    private void handleObjectStruct(JsonParser jParser, ObjectType objectType) throws IOException {
+    /**
+     * @param node this object's position in the value-collection tree, or {@code null} when enum
+     *             detection is off — see the {@code detectEnums} constructor parameter
+     */
+    private void handleObjectStruct(JsonParser jParser, ObjectType objectType, PathNode node) throws IOException {
         while (jParser.nextToken() != JsonToken.END_OBJECT) {
             JsonToken currentToken = jParser.currentToken();
             String name = jParser.currentName();
+            PathNode fieldNode = node == null ? null : node.field(name);
             JsonType value;
             if (currentToken == JsonToken.START_OBJECT) {
                 ObjectType nested = new ObjectType();
-                handleObjectStruct(jParser, nested);
+                handleObjectStruct(jParser, nested, fieldNode);
                 value = nested;
             }
             else if (currentToken == JsonToken.START_ARRAY) {
-                value = handleObjectArray(jParser);
+                value = handleObjectArray(jParser, fieldNode);
             }
             else if (currentToken.isScalarValue()) {
-                value = convertScalarToken(jParser, currentToken);
+                value = convertScalarToken(jParser, currentToken, fieldNode);
             }
             else {
                 continue;
@@ -142,20 +245,54 @@ public class JsonSchemaAnalyzer {
         }
     }
 
-    private ArrayType handleObjectArray(JsonParser jParser) throws IOException {
+    /**
+     * Folds samples into one combined shape, skipping any whose shape has already been folded
+     * in. Real sample sets repeat their shape heavily — only optionality and type differences
+     * produce a distinct one — and folding a shape that is already absorbed cannot change the
+     * result, so remembering what has been seen turns one merge per *sample* into one per
+     * distinct shape. That is the same win the previous {@link ArrayType}-based {@code -m} path
+     * got implicitly from its element set, kept here now that samples are merged as they stream.
+     */
+    private static final class SampleFolder {
+        private final Set<JsonType> folded = new HashSet<>();
+        private JsonType merged;
+
+        void fold(JsonType sample) {
+            if (merged == null) {
+                merged = sample;
+                folded.add(sample);
+                return;
+            }
+            if (folded.contains(sample)) {
+                return;
+            }
+            if (folded.size() < FOLDED_SHAPE_LIMIT) {
+                folded.add(sample);
+            }
+            merged = SchemaMerger.merge(merged, sample);
+        }
+
+        JsonType result() {
+            return merged;
+        }
+    }
+
+    private ArrayType handleObjectArray(JsonParser jParser, PathNode node) throws IOException {
+        // Every element shares one position, so their values pool into a single enum candidate.
+        PathNode elementNode = node == null ? null : node.element();
         ArrayType arrayType = new ArrayType();
         while (jParser.nextToken() != JsonToken.END_ARRAY) {
             JsonToken currentToken = jParser.currentToken();
 
             if (currentToken.isScalarValue()) {
-                arrayType.addField(convertScalarToken(jParser, currentToken));
+                arrayType.addField(convertScalarToken(jParser, currentToken, elementNode));
             }
             else if (currentToken == JsonToken.START_OBJECT) {
                 ObjectType objectType = new ObjectType();
-                handleObjectStruct(jParser, objectType);
+                handleObjectStruct(jParser, objectType, elementNode);
                 arrayType.addField(objectType);
             } else if (currentToken == JsonToken.START_ARRAY) {
-                arrayType.addField(handleObjectArray(jParser));
+                arrayType.addField(handleObjectArray(jParser, elementNode));
             }
         }
 
@@ -168,9 +305,11 @@ public class JsonSchemaAnalyzer {
      * @param jParser   the parser {@code jsonToken} was read from, used only to report a precise
      *                  location if {@code jsonToken} turns out to be unsupported
      * @param jsonToken a non-null {@link JsonToken}
+     * @param node      this value's position in the value-collection tree, or {@code null} when
+     *                  enum detection is off
      * @return the {@link ScalarType} matching the token
      */
-    private JsonType convertScalarToken(JsonParser jParser, JsonToken jsonToken) throws IOException {
+    private JsonType convertScalarToken(JsonParser jParser, JsonToken jsonToken, PathNode node) throws IOException {
         if (jsonToken == null) {
             throw new NullPointerException("JsonToken must not be null");
         }
@@ -179,9 +318,153 @@ public class JsonSchemaAnalyzer {
             case VALUE_TRUE, VALUE_FALSE -> ScalarType.BOOLEAN;
             case VALUE_NUMBER_FLOAT -> ScalarType.FLOAT;
             case VALUE_NUMBER_INT -> ScalarType.INTEGER;
-            case VALUE_STRING -> detectFormats ? StringFormatDetector.detect(jParser.getText()) : ScalarType.STRING;
+            case VALUE_STRING -> convertStringToken(jParser, node);
             case VALUE_NULL -> ScalarType.NULL;
             default -> throw JsonSchemaAnalysisException.unsupportedScalarToken(jsonToken, jParser.currentLocation());
         };
+    }
+
+    /**
+     * Resolves a string token's {@link ScalarType} and, when enum detection is on, records its
+     * literal text against {@code node} so {@link #applyEnums} can decide afterwards whether that
+     * position is an enum. The token's text is read at most once, and not at all when neither
+     * detection is enabled. A value that {@code -f} recognizes as a specific format poisons the
+     * position: those aren't categorical values, and reporting an enum built only from the
+     * position's *other* samples would misdescribe it.
+     */
+    private ScalarType convertStringToken(JsonParser jParser, PathNode node) throws IOException {
+        if (!detectFormats && node == null) {
+            return ScalarType.STRING;
+        }
+        String text = jParser.getText();
+        ScalarType scalarValue = detectFormats ? StringFormatDetector.detect(text) : ScalarType.STRING;
+        if (node != null) {
+            if (scalarValue == ScalarType.STRING) {
+                node.record(text);
+            } else {
+                node.poison();
+            }
+        }
+        return scalarValue;
+    }
+
+    private PathNode newRootNode() {
+        return detectEnums ? new PathNode() : null;
+    }
+
+    /**
+     * Replaces {@link ScalarType#STRING} with an {@link EnumType} at every position whose
+     * collected values qualify, rebuilding the shape around them. Run once, after the shape is
+     * final, so that nothing about it differed while it was being built or merged.
+     * <p>
+     * A {@link UnionType}'s string member is deliberately left alone — a position that is
+     * sometimes a non-string isn't a categorical value, matching how {@link SchemaMerger} already
+     * discards enum information on that kind of collision — but object and array members are
+     * still descended into so enums nested within them apply.
+     */
+    private static JsonType applyEnums(JsonType shape, PathNode node) {
+        if (node == null) {
+            return shape;
+        }
+        if (shape == ScalarType.STRING) {
+            return node.isEnum() ? new EnumType(node.values()) : shape;
+        }
+        if (shape instanceof ObjectType objectType) {
+            ObjectType result = new ObjectType();
+            for (Map.Entry<String, JsonType> entry : objectType.getFields().entrySet()) {
+                result.addField(entry.getKey(), applyEnums(entry.getValue(), node.existingField(entry.getKey())));
+            }
+            objectType.getOptionalFields().forEach(result::markOptional);
+            return result;
+        }
+        if (shape instanceof ArrayType arrayType) {
+            Set<JsonType> elements = arrayType.getFields();
+            // Every element pooled its values into one position, which only describes the array
+            // truthfully while the elements share a single shape. When they don't -- a
+            // discriminated union, say -- stamping the pooled set onto each shape would claim
+            // combinations that never occurred, so nothing under a heterogeneous array is
+            // substituted.
+            PathNode elementNode = elements.size() == 1 ? node.existingElement() : null;
+            ArrayType result = new ArrayType();
+            for (JsonType element : elements) {
+                result.addField(applyEnums(element, elementNode));
+            }
+            return result;
+        }
+        if (shape instanceof UnionType unionType) {
+            Set<JsonType> members = new LinkedHashSet<>();
+            for (JsonType member : unionType.getMembers()) {
+                members.add(member == ScalarType.STRING ? member : applyEnums(member, node));
+            }
+            return new UnionType(members);
+        }
+        return shape;
+    }
+
+    /**
+     * One position a string value can appear at, and the distinct values seen there. Array
+     * elements all share a single {@link #element()} node, so their values pool together.
+     * <p>
+     * A position stops collecting once it holds more than {@link EnumType#MAX_VALUES} values, or
+     * once a value there turns out to be a detected format, which bounds retained memory by the
+     * document's shape rather than by how much data it holds.
+     */
+    private static final class PathNode {
+        private final Map<String, PathNode> fields = new HashMap<>();
+        private PathNode element;
+        private Set<String> values;
+        private boolean poisoned;
+
+        PathNode field(String name) {
+            return fields.computeIfAbsent(name, ignored -> new PathNode());
+        }
+
+        PathNode element() {
+            if (element == null) {
+                element = new PathNode();
+            }
+            return element;
+        }
+
+        PathNode existingField(String name) {
+            return fields.get(name);
+        }
+
+        PathNode existingElement() {
+            return element;
+        }
+
+        void record(String value) {
+            if (poisoned) {
+                return;
+            }
+            // An empty or whitespace-padded value can't be told apart from the separators and
+            // indentation around it once rendered ("a[]: |b"), and isn't a useful categorical
+            // label anyway, so one is enough to disqualify the position.
+            if (value.isEmpty() || !value.equals(value.strip())) {
+                poison();
+                return;
+            }
+            if (values == null) {
+                values = new LinkedHashSet<>();
+            }
+            values.add(value);
+            if (values.size() > EnumType.MAX_VALUES) {
+                poison();
+            }
+        }
+
+        void poison() {
+            poisoned = true;
+            values = null;
+        }
+
+        boolean isEnum() {
+            return !poisoned && values != null && values.size() > 1;
+        }
+
+        Set<String> values() {
+            return values;
+        }
     }
 }

--- a/core/src/main/java/io/github/ssullivan/analyze/SchemaMerger.java
+++ b/core/src/main/java/io/github/ssullivan/analyze/SchemaMerger.java
@@ -34,6 +34,11 @@ public final class SchemaMerger {
         if (a.equals(b)) {
             return a;
         }
+        if (a instanceof EnumType ea && b instanceof EnumType eb) {
+            Set<String> union = new LinkedHashSet<>(ea.getValues());
+            union.addAll(eb.getValues());
+            return union.size() <= EnumType.MAX_VALUES ? new EnumType(union) : ScalarType.STRING;
+        }
         if (isNumberish(a) && isNumberish(b)) {
             return ScalarType.NUMBER;
         }
@@ -126,6 +131,7 @@ public final class SchemaMerger {
 
     private static boolean isStringish(JsonType type) {
         return type == ScalarType.STRING || type == ScalarType.DATE
-                || type == ScalarType.DATE_TIME || type == ScalarType.UUID;
+                || type == ScalarType.DATE_TIME || type == ScalarType.UUID
+                || type instanceof EnumType;
     }
 }

--- a/core/src/main/java/io/github/ssullivan/format/LlmWriter.java
+++ b/core/src/main/java/io/github/ssullivan/format/LlmWriter.java
@@ -16,7 +16,11 @@ import java.util.stream.Collectors;
  * heterogeneous types join their member labels with {@code |} the same way that class's
  * {@link UnionType} handling does — including collapsing an {@link ObjectType} or {@link ArrayType}
  * member down to the generic label {@code "object"}/{@code "array"}, since a fully nested
- * sub-shape doesn't fit on one joined line.
+ * sub-shape doesn't fit on one joined line, and likewise collapsing a multi-value
+ * {@link EnumType} member down to {@code "string"} when it's one of several members being
+ * joined, since its own pipe-joined value list can't be nested inside an outer pipe-joined
+ * member list without becoming ambiguous. A field whose sole type is an {@code EnumType} still
+ * shows its full value list — the collapse only applies when flattening it alongside others.
  */
 public final class LlmWriter {
     private LlmWriter() {
@@ -109,7 +113,7 @@ public final class LlmWriter {
         }
 
         String joined = elements.stream()
-                .map(LlmWriter::memberLabel)
+                .map(LlmWriter::flattenedMemberLabel)
                 .distinct()
                 .sorted()
                 .collect(Collectors.joining("|"));
@@ -119,10 +123,26 @@ public final class LlmWriter {
     private static String inlineLabel(JsonType type) {
         if (type instanceof UnionType unionType) {
             return unionType.getMembers().stream()
-                    .map(LlmWriter::memberLabel)
+                    .map(LlmWriter::flattenedMemberLabel)
                     .distinct()
                     .sorted()
                     .collect(Collectors.joining("|"));
+        }
+        return memberLabel(type);
+    }
+
+    /**
+     * Like {@link #memberLabel}, but additionally collapses a multi-value {@link EnumType} down
+     * to the generic {@code "string"} label. Used only when flattening more than one member
+     * shape into a single joined line — a {@link UnionType}'s members, or a heterogeneous
+     * {@link ArrayType}'s element shapes — where nesting an {@code EnumType}'s own pipe-joined
+     * value list inside that outer pipe-joined line would be ambiguous. Not used when a type is
+     * a field's sole/direct type ({@link #memberLabel} is used there instead), since there's no
+     * outer join for its values to be confused with in that case.
+     */
+    private static String flattenedMemberLabel(JsonType type) {
+        if (type instanceof EnumType) {
+            return "string";
         }
         return memberLabel(type);
     }

--- a/core/src/main/java/io/github/ssullivan/jackson/Json.java
+++ b/core/src/main/java/io/github/ssullivan/jackson/Json.java
@@ -16,8 +16,11 @@ import java.util.stream.Collectors;
 /**
  * Renders a {@link JsonType} shape as this project's compact notation: scalar types print as
  * their name ({@code "string"}, {@code "integer"}, ...), a {@link UnionType} prints as its
- * members joined with {@code |} (e.g. {@code "integer|string"}), and an {@link ObjectType}'s
- * optional fields get a {@code ?} suffix on the key (e.g. {@code "email?"}).
+ * members joined with {@code |} (e.g. {@code "integer|string"}) — collapsing an
+ * {@link ObjectType}/{@link ArrayType}/multi-value {@link EnumType} member down to the generic
+ * label {@code "object"}/{@code "array"}/{@code "string"}, since none of those fit unambiguously
+ * inside an outer pipe-joined member list — and an {@link ObjectType}'s optional fields get a
+ * {@code ?} suffix on the key (e.g. {@code "email?"}).
  * <p>
  * Rendering goes through {@link #write(Object)}. The underlying {@code ObjectMapper} is kept
  * private deliberately: it is shared across every call, and Jackson's thread-safety guarantee
@@ -51,6 +54,12 @@ public final class Json {
             @Override
             public void serialize(ScalarType jsonType, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
                 jsonGenerator.writeString(jsonType.toString());
+            }
+        });
+        module.addSerializer(EnumType.class, new JsonSerializer<>() {
+            @Override
+            public void serialize(EnumType enumType, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+                jsonGenerator.writeString(enumType.toString());
             }
         });
         module.addSerializer(UnionType.class, new JsonSerializer<>() {
@@ -98,6 +107,13 @@ public final class Json {
         }
         if (type instanceof ArrayType) {
             return "array";
+        }
+        if (type instanceof EnumType) {
+            // A multi-value EnumType's own toString() is already a pipe-joined list; treating
+            // that as one more atomic label here would nest one pipe-joined list inside another,
+            // making the two ambiguous (see LlmWriter.memberLabel, which applies the same rule).
+            // Collapse to the generic label instead, exactly like ObjectType/ArrayType above.
+            return "string";
         }
         return String.valueOf(type);
     }

--- a/core/src/main/java/io/github/ssullivan/jackson/JsonSchemaWriter.java
+++ b/core/src/main/java/io/github/ssullivan/jackson/JsonSchemaWriter.java
@@ -51,6 +51,9 @@ public final class JsonSchemaWriter {
         if (type instanceof UnionType unionType) {
             return unionSchema(unionType);
         }
+        if (type instanceof EnumType enumType) {
+            return enumSchema(enumType);
+        }
         throw new IllegalArgumentException("Unsupported JsonType: " + type);
     }
 
@@ -60,6 +63,23 @@ public final class JsonSchemaWriter {
         String format = jsonSchemaFormat(scalarType);
         if (format != null) {
             node.put("format", format);
+        }
+        return node;
+    }
+
+    /**
+     * A single-value enum renders exactly like plain {@link ScalarType#STRING} (no {@code enum}
+     * array), matching {@link EnumType#toString()}'s equivalent rule for the compact/LLM
+     * notations, so a field that merely happens to be constant across a small sample never leaks
+     * that value.
+     */
+    private static ObjectNode enumSchema(EnumType enumType) {
+        ObjectNode node = JsonNodeFactory.instance.objectNode();
+        node.put("type", "string");
+        Set<String> values = enumType.getValues();
+        if (values.size() > 1) {
+            ArrayNode enumNode = node.putArray("enum");
+            values.stream().sorted().forEach(enumNode::add);
         }
         return node;
     }

--- a/core/src/main/java/io/github/ssullivan/types/EnumType.java
+++ b/core/src/main/java/io/github/ssullivan/types/EnumType.java
@@ -1,0 +1,96 @@
+package io.github.ssullivan.types;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Represents a string field observed to take on only a small, fixed set of distinct literal
+ * values across merged samples — produced only by {@link io.github.ssullivan.analyze.SchemaMerger}
+ * and {@link io.github.ssullivan.analyze.JsonSchemaAnalyzer} when enum detection is enabled. A
+ * field whose distinct-value count exceeds {@link #MAX_VALUES} collapses to
+ * {@link ScalarType#STRING} instead of becoming (or remaining) an {@code EnumType}.
+ */
+public final class EnumType implements JsonType {
+
+    /**
+     * The maximum number of distinct values a field can hold and still be reported as an enum;
+     * beyond this, {@link io.github.ssullivan.analyze.SchemaMerger} falls back to the generic
+     * {@link ScalarType#STRING}.
+     */
+    public static final int MAX_VALUES = 5;
+
+    private final Set<String> values;
+
+    /**
+     * Creates an enum of the given values. The set is copied, so later changes to
+     * {@code values} do not affect this instance.
+     *
+     * @param values the distinct literal values observed in this position
+     */
+    public EnumType(Set<String> values) {
+        this.values = new LinkedHashSet<>(values);
+    }
+
+    /**
+     * Returns the values this enum is made of.
+     *
+     * @return an unmodifiable view of the enum's distinct values
+     */
+    public Set<String> getValues() {
+        return Collections.unmodifiableSet(values);
+    }
+
+    /**
+     * Creates an enum from the given values.
+     *
+     * @param values the distinct values; duplicates are collapsed
+     * @return the new enum
+     */
+    public static EnumType of(String... values) {
+        return new EnumType(new LinkedHashSet<>(Arrays.asList(values)));
+    }
+
+    /**
+     * Sorted, pipe-joined, unquoted values (e.g. {@code "active|inactive|pending"}) — or, when
+     * only one value has ever been observed, the generic {@link ScalarType#STRING} label, so a
+     * field that merely happens to be constant across a small sample never leaks that value.
+     * <p>
+     * A value containing a backslash, a pipe, or a newline is backslash-escaped first (e.g. a
+     * value literally equal to {@code "a|b"} renders as {@code a\|b}), so it can never be
+     * mistaken for a separator between two distinct values, and can never split the
+     * single-line-per-field notation this feeds into (see
+     * {@link io.github.ssullivan.format.LlmWriter}) across multiple lines.
+     */
+    @Override
+    public String toString() {
+        if (values.size() <= 1) {
+            return ScalarType.STRING.toString();
+        }
+        return values.stream().sorted().map(EnumType::escape).collect(Collectors.joining("|"));
+    }
+
+    private static String escape(String value) {
+        return value
+                .replace("\\", "\\\\")
+                .replace("|", "\\|")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EnumType enumType = (EnumType) o;
+        return Objects.equals(values, enumType.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(values);
+    }
+}

--- a/core/src/main/java/io/github/ssullivan/types/JsonType.java
+++ b/core/src/main/java/io/github/ssullivan/types/JsonType.java
@@ -3,12 +3,14 @@ package io.github.ssullivan.types;
 /**
  * The inferred shape of a JSON value — what this library produces instead of the value itself.
  * <p>
- * This is a sealed hierarchy of exactly four cases, so callers can pattern-match over it
+ * This is a sealed hierarchy of exactly five cases, so callers can pattern-match over it
  * exhaustively:
  * <ul>
  *   <li>{@link ObjectType} — named fields, each with its own shape, some possibly optional</li>
  *   <li>{@link ArrayType} — the distinct element shapes observed in an array</li>
  *   <li>{@link ScalarType} — a string, number, boolean, or null</li>
+ *   <li>{@link EnumType} — a string field observed to take on only a small, fixed set of
+ *       distinct literal values</li>
  *   <li>{@link UnionType} — more than one shape observed in the same position</li>
  * </ul>
  * Instances come from {@link io.github.ssullivan.analyze.JsonSchemaAnalyzer#parse} or
@@ -17,5 +19,5 @@ package io.github.ssullivan.types;
  * or {@link io.github.ssullivan.jackson.JsonSchemaWriter}.
  */
 public sealed interface JsonType
-        permits ArrayType, ObjectType, ScalarType, UnionType {
+        permits ArrayType, EnumType, ObjectType, ScalarType, UnionType {
 }

--- a/core/src/test/java/io/github/ssullivan/EnumTypeTest.java
+++ b/core/src/test/java/io/github/ssullivan/EnumTypeTest.java
@@ -1,0 +1,84 @@
+package io.github.ssullivan;
+
+import io.github.ssullivan.types.EnumType;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+class EnumTypeTest {
+
+    @Test
+    void testOfFactoryCreatesEnumWithGivenValues() {
+        EnumType enumType = EnumType.of("a", "b");
+
+        assertEquals(Set.of("a", "b"), enumType.getValues());
+    }
+
+    @Test
+    void testEqualsIsOrderIndependent() {
+        Set<String> forward = new LinkedHashSet<>(Set.of());
+        forward.add("a");
+        forward.add("b");
+
+        Set<String> backward = new LinkedHashSet<>(Set.of());
+        backward.add("b");
+        backward.add("a");
+
+        assertEquals(new EnumType(forward), new EnumType(backward));
+    }
+
+    @Test
+    void testDistinctValueSetsAreNotEqual() {
+        assertNotEquals(EnumType.of("a", "b"), EnumType.of("a", "c"));
+    }
+
+    @Test
+    void testToStringSingleValueRendersAsPlainStringLabel() {
+        assertEquals("string", EnumType.of("active").toString());
+    }
+
+    @Test
+    void testToStringMultipleValuesJoinsSortedWithPipe() {
+        assertEquals("a|b", EnumType.of("b", "a").toString());
+    }
+
+    @Test
+    void testToStringThreeValuesSortsAllOfThem() {
+        assertEquals("closed|open|pending", EnumType.of("pending", "open", "closed").toString());
+    }
+
+    @Test
+    void testToStringEscapesPipeInValue() {
+        // Without escaping, a value literally equal to "a|b" merged with "c" would render
+        // byte-identical to the genuine 3-value enum {"a", "b", "c"}
+        assertEquals("a\\|b|c", EnumType.of("a|b", "c").toString());
+    }
+
+    @Test
+    void testToStringDistinguishesValueContainingPipeFromSeparateValues() {
+        assertNotEquals(
+                EnumType.of("a", "b", "c").toString(),
+                EnumType.of("a|b", "c").toString()
+        );
+    }
+
+    @Test
+    void testToStringEscapesBackslashInValue() {
+        // Backslash must be escaped first, before pipe/newline escaping is applied, so a
+        // literal backslash in the value can't be mistaken for part of an escape sequence
+        assertEquals("a\\\\b|c", EnumType.of("a\\b", "c").toString());
+    }
+
+    @Test
+    void testToStringEscapesNewlineToKeepSingleLineOutput() {
+        String result = EnumType.of("line1\nline2", "c").toString();
+
+        assertEquals("c|line1\\nline2", result);
+        assertFalse(result.contains("\n"), "escaped output must not contain a raw newline");
+    }
+}

--- a/core/src/test/java/io/github/ssullivan/JsonSchemaAnalyzerTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonSchemaAnalyzerTest.java
@@ -393,13 +393,447 @@ class JsonSchemaAnalyzerTest {
         }
     }
 
+    @Test
+    void testEnumDetectionOffByDefaultLeavesStringsAsScalarType() throws IOException {
+        JsonType schema = inferSchema("{\"status\": \"active\"}", false, false);
+
+        assertEquals(ObjectType.of("status", ScalarType.STRING), schema);
+    }
+
+    @Test
+    void testSingleObservedValueIsNotReportedAsAnEnum() throws IOException {
+        // Only genuine variation is reported, so a field that merely happens to be constant
+        // never has its one value shown.
+        JsonType schema = inferSchema("{\"status\": \"active\"}", false, true);
+
+        assertEquals(ObjectType.of("status", ScalarType.STRING), schema);
+    }
+
+    @Test
+    void testEnumDetectionAppliesToBareArraysOfStrings() throws IOException {
+        // All elements of an array share one position, so their values pool into one enum.
+        JsonType schema = inferSchema("{\"tags\": [\"a\", \"b\", \"a\"]}", false, true);
+
+        assertEquals(ObjectType.of("tags", ArrayType.of(EnumType.of("a", "b"))), schema);
+    }
+
+    @Test
+    void testBareArrayOfStringsPastTheCapStaysPlainString() throws IOException {
+        JsonType schema = inferSchema("{\"tags\": [\"a\",\"b\",\"c\",\"d\",\"e\",\"f\"]}", false, true);
+
+        assertEquals(ObjectType.of("tags", ArrayType.of(ScalarType.STRING)), schema);
+    }
+
+    @Test
+    void testEnumDetectionAppliesInsideNestedObjects() throws IOException {
+        String ndjson = "{\"outer\":{\"status\":\"open\"}}\n{\"outer\":{\"status\":\"closed\"}}\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(
+                    ObjectType.of("outer", ObjectType.of("status", EnumType.of("open", "closed"))),
+                    schema
+            );
+        }
+    }
+
+    @Test
+    void testEnumDetectionAppliesToFieldsOfObjectsInsideAnArray() throws IOException {
+        // The limitation the previous design had to accept: values are collected per position
+        // rather than embedded in each element, so the array still dedupes to one element shape
+        // *and* the field gets its enum.
+        String json = "{\"items\": [{\"status\":\"open\"},{\"status\":\"closed\"},{\"status\":\"open\"}]}";
+
+        JsonType schema = inferSchema(json, false, true);
+
+        assertEquals(
+                ObjectType.of("items", ArrayType.of(ObjectType.of("status", EnumType.of("open", "closed")))),
+                schema
+        );
+    }
+
+    @Test
+    void testEnumDetectionAppliesToObjectsNestedDeeperInsideAnArray() throws IOException {
+        String json = "{\"items\": [{\"inner\":{\"status\":\"open\"}},{\"inner\":{\"status\":\"closed\"}}]}";
+
+        JsonType schema = inferSchema(json, false, true);
+
+        assertEquals(
+                ObjectType.of("items", ArrayType.of(
+                        ObjectType.of("inner", ObjectType.of("status", EnumType.of("open", "closed"))))),
+                schema
+        );
+    }
+
+    @Test
+    void testHeterogeneousArrayGetsNoEnumsSincePooledValuesWouldMisdescribeIt() throws IOException {
+        // A discriminated union: the two element shapes differ, so the values pooled at the
+        // shared element position don't belong to either shape individually. Stamping
+        // "click|scroll" onto both would describe records like {"type":"click","dy":2} that
+        // never occurred, so nothing under the array is substituted.
+        String json = "{\"events\":[{\"type\":\"click\",\"x\":1},{\"type\":\"scroll\",\"dy\":2}]}";
+
+        JsonType schema = inferSchema(json, false, true);
+
+        assertInstanceOf(ObjectType.class, schema);
+        ArrayType events = (ArrayType) ((ObjectType) schema).getFields().get("events");
+        assertEquals(2, events.getFields().size());
+        for (JsonType element : events.getFields()) {
+            assertEquals(ScalarType.STRING, ((ObjectType) element).getFields().get("type"));
+        }
+    }
+
+    @Test
+    void testUniformArrayStillGetsEnumsAfterTheHeterogeneousGuard() throws IOException {
+        // The guard keys off the number of distinct element shapes, so an array whose elements
+        // agree -- the case this feature is for -- is unaffected.
+        String json = "{\"events\":[{\"type\":\"click\",\"x\":1},{\"type\":\"scroll\",\"x\":2}]}";
+
+        JsonType schema = inferSchema(json, false, true);
+
+        ArrayType events = (ArrayType) ((ObjectType) schema).getFields().get("events");
+        assertEquals(1, events.getFields().size());
+        assertEquals(
+                EnumType.of("click", "scroll"),
+                ((ObjectType) events.getFields().iterator().next()).getFields().get("type")
+        );
+    }
+
+    @Test
+    void testEmptyStringValueDisqualifiesThePosition() throws IOException {
+        // Rendered, an empty value would be indistinguishable from the separator around it
+        // ("a[]: |b"), so it is not treated as an enum value.
+        JsonType schema = inferSchema("{\"a\": [\"\", \"b\"]}", false, true);
+
+        assertEquals(ObjectType.of("a", ArrayType.of(ScalarType.STRING)), schema);
+    }
+
+    @Test
+    void testWhitespacePaddedValueDisqualifiesThePosition() throws IOException {
+        JsonType schema = inferSchema("{\"a\": [\" x\", \"y\"]}", false, true);
+
+        assertEquals(ObjectType.of("a", ArrayType.of(ScalarType.STRING)), schema);
+    }
+
+    @Test
+    void testEnumDetectionAppliesAtDepthThroughMixedNesting() throws IOException {
+        // a.b[].c.d -- proves position descent is correct through both field and element steps.
+        String json = "{\"a\":{\"b\":[{\"c\":{\"d\":\"x\"}},{\"c\":{\"d\":\"y\"}}]}}";
+
+        JsonType schema = inferSchema(json, false, true);
+
+        assertEquals(
+                ObjectType.of("a", ObjectType.of("b", ArrayType.of(
+                        ObjectType.of("c", ObjectType.of("d", EnumType.of("x", "y")))))),
+                schema
+        );
+    }
+
+    @Test
+    void testArrayOfRecordsDedupesToOneElementShapeAndStillDetectsTheEnum() throws IOException {
+        // The regression this feature originally shipped with: distinct EnumTypes embedded in
+        // each record made them unequal, so a 3-record array kept 3 element shapes and the LLM
+        // notation collapsed the whole thing to a bare "object" label. Now the shape is built
+        // enum-free and values are substituted in afterwards, so both properties hold at once.
+        String json = "[{\"id\":1,\"status\":\"open\"},{\"id\":2,\"status\":\"closed\"},{\"id\":3,\"status\":\"pending\"}]";
+
+        JsonType schema = inferSchema(json, false, true);
+
+        assertInstanceOf(ArrayType.class, schema);
+        assertEquals(1, ((ArrayType) schema).getFields().size());
+
+        ObjectType expectedElement = new ObjectType();
+        expectedElement.addField("id", ScalarType.INTEGER);
+        expectedElement.addField("status", EnumType.of("open", "closed", "pending"));
+        assertEquals(ArrayType.of(expectedElement), schema);
+    }
+
+    @Test
+    void testParseSamplesMergesTopLevelArrayElementsIntoAnEnum() throws IOException {
+        String json = "[{\"status\":\"open\"},{\"status\":\"closed\"},{\"status\":\"pending\"}]";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseSamples(inputStream);
+
+            assertEquals(ObjectType.of("status", EnumType.of("open", "closed", "pending")), schema);
+        }
+    }
+
+    @Test
+    void testParseSamplesDetectsEnumsInsideNestedArraysWhileKeepingOneElementShape() throws IOException {
+        String json = "[{\"id\":1,\"tags\":[{\"k\":\"a\"}]},{\"id\":2,\"tags\":[{\"k\":\"b\"}]}]";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseSamples(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            JsonType tagsType = ((ObjectType) schema).getFields().get("tags");
+            assertEquals(ArrayType.of(ObjectType.of("k", EnumType.of("a", "b"))), tagsType);
+        }
+    }
+
+    @Test
+    void testParseJsonLinesDetectsEnumsInsideNestedArraysWhileKeepingOneElementShape() throws IOException {
+        String ndjson = "{\"tags\":[{\"k\":\"a\"}]}\n{\"tags\":[{\"k\":\"b\"}]}\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("tags", ArrayType.of(ObjectType.of("k", EnumType.of("a", "b")))), schema);
+        }
+    }
+
+    @Test
+    void testMixedFormatAndPlainStringAtOnePositionIsNotAnEnum() throws IOException {
+        // With -f on, one sample's value is a date and another's is not. Reporting an enum built
+        // only from the non-date samples would misdescribe the position, so it stays a string.
+        String ndjson = "{\"d\":\"2023-01-15\"}\n{\"d\":\"whenever\"}\n{\"d\":\"whenever\"}\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(true, true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("d", ScalarType.STRING), schema);
+        }
+    }
+
+    @Test
+    void testPositionThatMergesToAUnionIsNotReportedAsAnEnum() throws IOException {
+        // `id` is a low-cardinality string in some samples and an integer in others, so it isn't
+        // a categorical value -- the collected values are discarded rather than shown.
+        String ndjson = "{\"id\":\"a\"}\n{\"id\":\"b\"}\n{\"id\":1}\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            JsonType idType = ((ObjectType) schema).getFields().get("id");
+            assertInstanceOf(UnionType.class, idType);
+            assertEquals(Set.of(ScalarType.INTEGER, ScalarType.STRING), ((UnionType) idType).getMembers());
+        }
+    }
+
+    @Test
+    void testEnumsNestedInsideAUnionsObjectMemberStillApply() throws IOException {
+        // The union itself gets no enum, but object members of it are still descended into.
+        String ndjson = "{\"x\":{\"k\":\"a\"}}\n{\"x\":{\"k\":\"b\"}}\n{\"x\":1}\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            JsonType xType = ((ObjectType) schema).getFields().get("x");
+            assertInstanceOf(UnionType.class, xType);
+            assertTrue(((UnionType) xType).getMembers()
+                    .contains(ObjectType.of("k", EnumType.of("a", "b"))));
+        }
+    }
+
+    @Test
+    void testOptionalityIsPreservedThroughEnumSubstitution() throws IOException {
+        String ndjson = "{\"id\":1,\"status\":\"open\"}\n{\"id\":2}\n{\"id\":3,\"status\":\"closed\"}\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            ObjectType objectType = (ObjectType) schema;
+            assertFalse(objectType.isOptional("id"));
+            assertTrue(objectType.isOptional("status"));
+            assertEquals(EnumType.of("open", "closed"), objectType.getFields().get("status"));
+        }
+    }
+
+    @Test
+    void testParseSamplesOnNonArrayRootDescribesTheDocumentItself() throws IOException {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream("{\"id\": 1}".getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer().parseSamples(inputStream);
+
+            assertEquals(ObjectType.of("id", ScalarType.INTEGER), schema);
+        }
+    }
+
+    @Test
+    void testParseSamplesOnEmptyArrayYieldsEmptyArrayType() throws IOException {
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream("[]".getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer().parseSamples(inputStream);
+
+            assertEquals(new ArrayType(), schema);
+        }
+    }
+
+    @Test
+    void testParseSamplesMergesOptionalityTheSameWayTheOldMergeReduceDid() throws IOException {
+        String json = "[{\"id\": 1, \"name\": \"Alice\"}, {\"id\": 2}]";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer().parseSamples(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            ObjectType objectType = (ObjectType) schema;
+            assertFalse(objectType.isOptional("id"));
+            assertTrue(objectType.isOptional("name"));
+        }
+    }
+
+    @Test
+    void testParseSamplesSkippingAlreadyFoldedShapesKeepsOptionality() throws IOException {
+        // Samples repeat their shape, so identical ones are skipped rather than re-merged. That
+        // is only safe because folding an already-absorbed shape cannot change the result -- if
+        // the skip were wrong, "name" would come back required here.
+        String json = "[{\"id\":1,\"name\":\"a\"},{\"id\":2},{\"id\":3,\"name\":\"b\"},{\"id\":4}]";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer().parseSamples(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            ObjectType objectType = (ObjectType) schema;
+            assertFalse(objectType.isOptional("id"));
+            assertTrue(objectType.isOptional("name"));
+            assertEquals(ScalarType.STRING, objectType.getFields().get("name"));
+        }
+    }
+
+    @Test
+    void testParseSamplesSkippingAlreadyFoldedShapesKeepsUnions() throws IOException {
+        String json = "[{\"id\":1},{\"id\":\"two\"},{\"id\":3},{\"id\":\"four\"}]";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer().parseSamples(inputStream);
+
+            assertInstanceOf(ObjectType.class, schema);
+            JsonType idType = ((ObjectType) schema).getFields().get("id");
+            assertInstanceOf(UnionType.class, idType);
+            assertEquals(Set.of(ScalarType.INTEGER, ScalarType.STRING), ((UnionType) idType).getMembers());
+        }
+    }
+
+    @Test
+    void testParseSamplesStaysCorrectPastTheFoldedShapeLimit() throws IOException {
+        // More structurally distinct samples than the dedupe cache holds, so it stops
+        // deduplicating partway through and falls back to plain merging; the result must be
+        // unaffected. Enum detection on a unique-per-sample field is the natural way to get
+        // there, and the values also blow past MAX_VALUES, so the field ends up plain "string".
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < 1100; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("{\"id\":").append(i).append(",\"tag\":\"v").append(i).append("\"}");
+        }
+        json.append(']');
+
+        try (ByteArrayInputStream inputStream =
+                     new ByteArrayInputStream(json.toString().getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseSamples(inputStream);
+
+            ObjectType expected = new ObjectType();
+            expected.addField("id", ScalarType.INTEGER);
+            expected.addField("tag", ScalarType.STRING);
+            assertEquals(expected, schema);
+        }
+    }
+
+    @Test
+    void testParseSamplesMalformedInputReportsLocation() {
+        assertThrows(JsonSchemaAnalysisException.class, () -> {
+            try (ByteArrayInputStream inputStream =
+                         new ByteArrayInputStream("[{\"a\": }]".getBytes(StandardCharsets.UTF_8))) {
+                new JsonSchemaAnalyzer().parseSamples(inputStream);
+            }
+        });
+    }
+
+    @Test
+    void testEnumDetectionDoesNotApplyToDetectedDateOrUuidFields() throws IOException {
+        JsonType schema = inferSchema("{\"day\": \"2023-01-15\"}", true, true);
+
+        assertEquals(ObjectType.of("day", ScalarType.DATE), schema);
+    }
+
+    @Test
+    void testSameValueOnEveryJsonLineIsNotReportedAsAnEnum() throws IOException {
+        String ndjson = String.join("\n",
+                "{\"status\": \"active\"}",
+                "{\"status\": \"active\"}");
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("status", ScalarType.STRING), schema);
+        }
+    }
+
+    @Test
+    void testEnumDetectionMergesDistinctValuesAcrossJsonLines() throws IOException {
+        String ndjson = String.join("\n",
+                "{\"status\": \"open\"}",
+                "{\"status\": \"closed\"}",
+                "{\"status\": \"pending\"}");
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("status", EnumType.of("open", "closed", "pending")), schema);
+        }
+    }
+
+    @Test
+    void testEnumDetectionStaysEnumAtExactlyFiveDistinctValues() throws IOException {
+        String ndjson = String.join("\n",
+                "{\"status\": \"a\"}",
+                "{\"status\": \"b\"}",
+                "{\"status\": \"c\"}",
+                "{\"status\": \"d\"}",
+                "{\"status\": \"e\"}");
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("status", EnumType.of("a", "b", "c", "d", "e")), schema);
+        }
+    }
+
+    @Test
+    void testEnumDetectionFallsBackToPlainStringPastCardinalityCap() throws IOException {
+        String ndjson = String.join("\n",
+                "{\"status\": \"a\"}",
+                "{\"status\": \"b\"}",
+                "{\"status\": \"c\"}",
+                "{\"status\": \"d\"}",
+                "{\"status\": \"e\"}",
+                "{\"status\": \"f\"}");
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(ObjectType.of("status", ScalarType.STRING), schema);
+        }
+    }
+
+    @Test
+    void testRootLevelScalarsPoolIntoAnEnumAcrossJsonLines() throws IOException {
+        // Bare root scalars occupy one position too, so they pool like any other.
+        String ndjson = "\"active\"\n\"inactive\"\n";
+
+        try (ByteArrayInputStream inputStream = new ByteArrayInputStream(ndjson.getBytes(StandardCharsets.UTF_8))) {
+            JsonType schema = new JsonSchemaAnalyzer(false, true).parseJsonLines(inputStream);
+
+            assertEquals(EnumType.of("active", "inactive"), schema);
+        }
+    }
+
     private JsonType inferSchema(String json) throws IOException {
         return inferSchema(json, false);
     }
 
     private JsonType inferSchema(String json, boolean detectFormats) throws IOException {
+        return inferSchema(json, detectFormats, false);
+    }
+
+    private JsonType inferSchema(String json, boolean detectFormats, boolean detectEnums) throws IOException {
         try (ByteArrayInputStream inputStream = new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))) {
-            JsonSchemaAnalyzer jsonSchemaAnalyzer = new JsonSchemaAnalyzer(detectFormats);
+            JsonSchemaAnalyzer jsonSchemaAnalyzer = new JsonSchemaAnalyzer(detectFormats, detectEnums);
             return jsonSchemaAnalyzer.parse(inputStream);
         }
     }

--- a/core/src/test/java/io/github/ssullivan/JsonSchemaWriterTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonSchemaWriterTest.java
@@ -217,6 +217,43 @@ class JsonSchemaWriterTest {
     }
 
     @Test
+    void testEnumScalarEmitsTypeStringAndSortedEnumArray() {
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(EnumType.of("closed", "open", "pending"));
+
+        assertEquals("string", schema.get("type").asText());
+        List<String> values = new ArrayList<>();
+        schema.get("enum").forEach(node -> values.add(node.asText()));
+        assertEquals(List.of("closed", "open", "pending"), values);
+    }
+
+    @Test
+    void testSingleValueEnumOmitsEnumArray() {
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(EnumType.of("active"));
+
+        assertEquals("string", schema.get("type").asText());
+        assertFalse(schema.has("enum"));
+    }
+
+    @Test
+    void testUnionWithEnumMemberUsesAnyOfNotTypeArray() {
+        UnionType unionType = new UnionType(Set.of(EnumType.of("open", "closed"), ScalarType.INTEGER));
+
+        ObjectNode schema = JsonSchemaWriter.toJsonSchema(unionType);
+
+        assertFalse(schema.has("type"));
+        assertTrue(schema.get("anyOf").isArray());
+        assertEquals(2, schema.get("anyOf").size());
+
+        boolean anyMemberHasEnum = false;
+        for (var member : schema.get("anyOf")) {
+            if (member.has("enum")) {
+                anyMemberHasEnum = true;
+            }
+        }
+        assertTrue(anyMemberHasEnum);
+    }
+
+    @Test
     void testToJsonSchemaRejectsNull() {
         assertThrows(NullPointerException.class, () -> JsonSchemaWriter.toJsonSchema(null));
     }

--- a/core/src/test/java/io/github/ssullivan/JsonTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonTest.java
@@ -128,6 +128,47 @@ class JsonTest {
     }
 
     @Test
+    void testEnumRendersAsSortedPipeJoinedValues() throws Exception {
+        assertEquals("\"a|b|c\"", Json.write(EnumType.of("b", "a", "c")));
+    }
+
+    @Test
+    void testSingleValueEnumRendersAsPlainString() throws Exception {
+        assertEquals("\"string\"", Json.write(EnumType.of("active")));
+    }
+
+    @Test
+    void testEnumFieldInsideObjectRendersInline() throws Exception {
+        ObjectType root = ObjectType.of("status", EnumType.of("open", "closed"));
+
+        assertEquals("""
+                {
+                  "status" : "closed|open"
+                }""", Json.write(root));
+    }
+
+    @Test
+    void testUnionWithMultiValueEnumMemberCollapsesToGenericStringLabel() throws Exception {
+        // A multi-value EnumType's own toString() is already a pipe-joined list; if it were
+        // treated as one more atomic union member label, "closed|open" nested inside the outer
+        // "|"-join would be indistinguishable from a 3-way union/enum of "closed", "open", and
+        // "integer". It must collapse to the generic "string" label instead, exactly like an
+        // ObjectType/ArrayType member does.
+        UnionType union = new UnionType(Set.of(ScalarType.INTEGER, EnumType.of("open", "closed")));
+
+        assertEquals("\"integer|string\"", Json.write(union));
+    }
+
+    @Test
+    void testUnionWithEnumAndPlainStringMembersDedupesGenericLabel() throws Exception {
+        // Both an EnumType member and a plain STRING member collapse to the same "string"
+        // label; without deduping, this would render as "string|string"
+        UnionType union = new UnionType(Set.of(ScalarType.STRING, EnumType.of("open", "closed")));
+
+        assertEquals("\"string\"", Json.write(union));
+    }
+
+    @Test
     void testMatchesTheReadmeExampleOutput() throws Exception {
         // The exact document from README "Example1: JSON Object".
         ObjectType product = new ObjectType();

--- a/core/src/test/java/io/github/ssullivan/JsonTypeEncapsulationTest.java
+++ b/core/src/test/java/io/github/ssullivan/JsonTypeEncapsulationTest.java
@@ -45,4 +45,12 @@ class JsonTypeEncapsulationTest {
         assertThrows(UnsupportedOperationException.class, () -> unionType.getMembers().clear());
         assertEquals(2, unionType.getMembers().size());
     }
+
+    @Test
+    void testEnumTypeValuesAreUnmodifiable() {
+        EnumType enumType = EnumType.of("a", "b");
+
+        assertThrows(UnsupportedOperationException.class, () -> enumType.getValues().clear());
+        assertEquals(2, enumType.getValues().size());
+    }
 }

--- a/core/src/test/java/io/github/ssullivan/LlmWriterTest.java
+++ b/core/src/test/java/io/github/ssullivan/LlmWriterTest.java
@@ -180,6 +180,38 @@ class LlmWriterTest {
     }
 
     @Test
+    void testEnumFieldRendersAsSortedPipeJoinedValues() {
+        ObjectType root = ObjectType.of("status", EnumType.of("b", "a"));
+
+        assertEquals("status: a|b", LlmWriter.write(root));
+    }
+
+    @Test
+    void testSingleValueEnumFieldRendersAsPlainString() {
+        ObjectType root = ObjectType.of("status", EnumType.of("active"));
+
+        assertEquals("status: string", LlmWriter.write(root));
+    }
+
+    @Test
+    void testHeterogeneousArrayWithMultiValueEnumElementCollapsesToGenericStringLabel() {
+        ObjectType root = ObjectType.of("values", ArrayType.of(ScalarType.INTEGER, EnumType.of("open", "closed")));
+
+        assertEquals("values[]: integer|string", LlmWriter.write(root));
+    }
+
+    @Test
+    void testUnionWithMultiValueEnumMemberCollapsesToGenericStringLabel() {
+        // Nesting a multi-value EnumType's own pipe-joined values inside the outer union join
+        // would be ambiguous (e.g. indistinguishable from a 3-way union); it must collapse to
+        // the generic "string" label instead, exactly like an ObjectType/ArrayType member does.
+        ObjectType root = new ObjectType();
+        root.addField("id", new UnionType(Set.of(ScalarType.INTEGER, EnumType.of("open", "closed"))));
+
+        assertEquals("id: integer|string", LlmWriter.write(root));
+    }
+
+    @Test
     void testWriteRejectsNull() {
         assertThrows(NullPointerException.class, () -> LlmWriter.write(null));
     }

--- a/core/src/test/java/io/github/ssullivan/SchemaMergerTest.java
+++ b/core/src/test/java/io/github/ssullivan/SchemaMergerTest.java
@@ -170,6 +170,79 @@ class SchemaMergerTest {
     }
 
     @Test
+    void testMergingTwoEnumTypesUnionsTheirValues() {
+        JsonType merged = SchemaMerger.merge(EnumType.of("open"), EnumType.of("closed"));
+
+        assertEquals(EnumType.of("open", "closed"), merged);
+    }
+
+    @Test
+    void testMergingIdenticalEnumTypesReturnsSameValue() {
+        JsonType merged = SchemaMerger.merge(EnumType.of("open"), EnumType.of("open"));
+
+        assertEquals(EnumType.of("open"), merged);
+    }
+
+    @Test
+    void testMergingEnumTypesUpToCapStaysEnum() {
+        EnumType a = EnumType.of("a", "b", "c");
+        EnumType b = EnumType.of("c", "d", "e");
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(EnumType.of("a", "b", "c", "d", "e"), merged);
+    }
+
+    @Test
+    void testMergingEnumTypesPastCapCollapsesToString() {
+        EnumType a = EnumType.of("a", "b", "c");
+        EnumType b = EnumType.of("d", "e", "f");
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(ScalarType.STRING, merged);
+    }
+
+    @Test
+    void testEnumTypeCollidingWithDateCollapsesToString() {
+        JsonType merged = SchemaMerger.merge(EnumType.of("a"), ScalarType.DATE);
+
+        assertEquals(ScalarType.STRING, merged);
+    }
+
+    @Test
+    void testEnumTypeCollidingWithUuidCollapsesToString() {
+        JsonType merged = SchemaMerger.merge(EnumType.of("a"), ScalarType.UUID);
+
+        assertEquals(ScalarType.STRING, merged);
+    }
+
+    @Test
+    void testEnumTypeCollidingWithPlainStringCollapsesToString() {
+        JsonType merged = SchemaMerger.merge(EnumType.of("a"), ScalarType.STRING);
+
+        assertEquals(ScalarType.STRING, merged);
+    }
+
+    @Test
+    void testEnumTypeDoesNotCollapseAgainstNonStringTypes() {
+        JsonType merged = SchemaMerger.merge(EnumType.of("a"), ScalarType.INTEGER);
+
+        assertInstanceOf(UnionType.class, merged);
+        assertEquals(Set.of(EnumType.of("a"), ScalarType.INTEGER), ((UnionType) merged).getMembers());
+    }
+
+    @Test
+    void testMergingArraysWithHandBuiltEnumTypesCollapsesViaCollapseStrings() {
+        ArrayType a = ArrayType.of(EnumType.of("x"));
+        ArrayType b = ArrayType.of(EnumType.of("y"));
+
+        JsonType merged = SchemaMerger.merge(a, b);
+
+        assertEquals(ArrayType.of(ScalarType.STRING), merged);
+    }
+
+    @Test
     void testMergeRejectsNullArguments() {
         assertThrows(NullPointerException.class, () -> SchemaMerger.merge(null, ScalarType.STRING));
         assertThrows(NullPointerException.class, () -> SchemaMerger.merge(ScalarType.STRING, null));


### PR DESCRIPTION
## Summary

The third of the three improvements from this round, after NDJSON input (#6) and string format detection (#7/#8). A string field that only ever takes a handful of distinct values — a status or category — is far more useful reported as those values than as generic `string`, and it costs nothing in output size.

`-e`/`--detect-enums`, off by default:

```shell
$ printf '[{"id":1,"status":"open"},{"id":2,"status":"closed"},{"id":3,"status":"pending"}]' \
    | json-analyze -m -e -l
id: integer
status: closed|open|pending
```

A position holding 2–5 distinct values is reported as an enum. More than that falls back to plain `string` with no values shown, as does a position holding a single value — so a field that merely happens to be constant never leaks it.

## Design note: values are collected by position, not embedded in the shape

Worth calling out, because the obvious implementation doesn't work. Wrapping a string in an `EnumType` as it's parsed makes otherwise identical records *unequal*, and `ArrayType` dedupes elements by equality without merging them — so an array fractures into one element shape per distinct value, losing the array's shape entirely and making merges quadratic.

Instead, values are recorded against the position they were seen at and substituted in by one pass once the shape is final. While the shape is being built and merged it is identical to what `-e` off produces, so dedupe and merging are untouched and the fracturing is structurally impossible. Detection therefore works at any depth — including fields of objects inside an array, and bare arrays of strings, whose elements share one position and pool their values:

```shell
$ echo '{"tags": ["a","b","a"], "items": [{"k":"x"},{"k":"y"}]}' | json-analyze -e -l
items[]:
  k: x|y
tags[]: a|b
```

Retained memory is bounded by the document's shape rather than by its data, which matches the property the tool is built around.

Two guards keep the pooling honest:
- An array whose elements have **more than one shape** gets no substitution at all — values pooled across a discriminated union belong to no single shape, and stamping them onto each would describe records that never occurred.
- An **empty or whitespace-padded** value disqualifies its position, being indistinguishable from the separators around it once rendered. Values containing a backslash, pipe or newline are escaped for the same reason.

A position that is sometimes a detected `date`/`uuid` (with `-f`), or that varies in type across samples, gets no enum either.

## Supporting changes

- **`EnumType`**, a new `JsonType`; the sealed hierarchy is widened to permit it. `Json` needs a serializer; `LlmWriter` needs none. Both collapse a multi-value enum to the generic `string` label inside a union, where its own pipe-joined values would otherwise be ambiguous.
- **`JsonSchemaWriter`** emits a real draft-07 `enum` array, which is never ambiguous — so `-s` disambiguates anything the compact notations can't.
- **`SchemaMerger`** unions two enums under the cap, and collapses to `string` past it or on collision with a non-enum string.
- **`JsonSchemaAnalyzer.parseSamples`** streams a top-level array's elements as samples instead of building an intermediate `ArrayType`; this is what `-m` now calls. `SampleFolder` skips folding a shape already absorbed, since doing so cannot change the result.

## Performance

Measured on the 100k-record / 17.5 MB benchmark corpus (`bench/benchmark.py`'s generator, deliberately heterogeneous):

| | `-m` | `-m -e` |
| --- | --- | --- |
| baseline | 690 ms | — |
| this PR | 690 ms | 803 ms (~1.16×) |

With `-e` off, `-m` output is **byte-identical** to `main` across 8 flag combinations × 3 corpora, and `just bench` output sizes are unchanged (155 / 243 / 842 B).

## Test plan

- [x] `./mvnw clean install -DskipITs` — full suite green; ~90 tests added across `EnumTypeTest`, `JsonSchemaAnalyzerTest`, `SchemaMergerTest`, `JsonSchemaWriterTest`, `JsonTest`, `LlmWriterTest`, `JsonTypeEncapsulationTest`, `MainTest`
- [x] Manual verification of each documented claim against the built jar, including every README example
- [x] Byte-for-byte output equivalence with `main` for all non-`-e` paths
- [x] `just bench` — output sizes and timings unchanged
- Note: `ShadedJarIT` fails in my sandbox because `JAVA_TOOL_OPTIONS` proxy settings pollute stdout — pre-existing and unrelated, same as noted in #6

## Versioning

MINOR by the same judgment call already documented for format detection: this adds a new `ScalarType`-adjacent member to what `JsonType` permits, which the policy would normally flag MAJOR, but detection is strictly opt-in so no existing caller's output changes. The POM is untouched — bump at release time.

## Known limits (documented, not fixed)

- A heterogeneous array gets no enums at all. Correct by construction, but blunt; per-element-shape pooling would need shape identity that isn't available at parse time.
- An enum whose values are themselves type names (`"string"`, `"integer"`) renders like a genuine type union in the compact notations. `-s` disambiguates.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AAJqLraEZMGqPR5QVfXiwa)_